### PR TITLE
slidechain: read a recipient for the import tx from the memo field of the peg-in tx

### DIFF
--- a/slidechain/import.go
+++ b/slidechain/import.go
@@ -13,23 +13,36 @@ func (c *custodian) importFromPegs(ctx context.Context, s *submitter) error {
 	for {
 		c.imports.Wait()
 		var (
-			txids                  []string
-			operationNums, amounts []int
-			assets                 [][]byte
+			txids          []string
+			opNums         []int
+			amounts        []int64
+			assets, recips [][]byte
 		)
-		const q = `SELECT txid, txhash, operation_num, amount, asset FROM pegs WHERE imported=0`
-		err := sqlutil.ForQueryRows(ctx, c.db, q, func(txid string, txhash []byte, operationNum, amount int, asset []byte) {
+		const q = `SELECT txid, txhash, operation_num, amount, asset, recipient_pubkey FROM pegs WHERE imported=0`
+		err := sqlutil.ForQueryRows(ctx, c.db, q, func(txid string, txhash []byte, opNum int, amount int64, asset, recip []byte) {
 			txids = append(txids, txid)
-			operationNums = append(operationNums, operationNum)
+			opNums = append(opNums, opNum)
 			amounts = append(amounts, amount)
 			assets = append(assets, asset)
+			recips = append(recips, recip)
 		})
-		// TODO: import the specified row through issuance contract
-		for _, txid := range txids {
-			_, err = c.db.ExecContext(ctx, `UPDATE pegs SET imported=1 WHERE txid=$1`, txid)
+		for i, txid := range txids {
+			var (
+				opNum  = opNums[i]
+				amount = amounts[i]
+				asset  = assets[i]
+				recip  = recips[i]
+			)
+			err = c.doImport(ctx, s, txid, opNum, amount, asset, recip) // TODO(bobg): probably s should be a field in the custodian object
 			if err != nil {
-				return errors.Wrapf(err, "updating record for tx %s", txid)
+				return errors.Wrapf(err, "importing from tx %s, operation %d", txid, opNum)
 			}
 		}
 	}
+}
+
+func (c *custodian) doImport(ctx context.Context, s *submitter, txid string, opNum int, amount int64, assetXDR, recip []byte) error {
+	// TODO: build and submit import transaction
+	_, err := c.db.ExecContext(ctx, `UPDATE pegs SET imported=1 WHERE txid = $1 AND operation_num = $2`, txid, opNum)
+	return errors.Wrapf(err, "setting imported=1 for txid %s, operation %d", txid, opNum)
 }

--- a/slidechain/schema.go
+++ b/slidechain/schema.go
@@ -17,7 +17,9 @@ CREATE TABLE IF NOT EXISTS pegs (
   operation_num INTEGER NOT NULL,
   amount INTEGER NOT NULL,
   asset_xdr BLOB NOT NULL,
-  imported INTEGER NOT NULL DEFAULT 0
+  recipient_pubkey BLOB NOT NULL,
+  imported INTEGER NOT NULL DEFAULT 0,
+  PRIMARY KEY (txid, operation_num)
 );
 
 CREATE TABLE IF NOT EXISTS exports (

--- a/slidechain/watch.go
+++ b/slidechain/watch.go
@@ -21,6 +21,11 @@ func (c *custodian) watchPegs(tx horizon.Transaction) {
 		return
 	}
 
+	if env.Tx.Memo.Type != xdr.MemoTypeMemoHash {
+		return
+	}
+	recipientPubkey := (*env.Tx.Memo.Hash)[:]
+
 	for i, op := range env.Tx.Operations {
 		if op.Body.Type != xdr.OperationTypePayment {
 			continue
@@ -33,14 +38,14 @@ func (c *custodian) watchPegs(tx horizon.Transaction) {
 		// This operation is a payment to the custodian's account - i.e., a peg.
 		// We record it in the db, then wake up a goroutine that executes imports for not-yet-imported pegs.
 		var q = `INSERT INTO pegs 
-				(txid, operation_num, amount, asset_xdr, imported)
+				(txid, operation_num, amount, asset_xdr, recipient_pubkey)
 				VALUES ($1, $2, $3, $4, $5)`
 		assetXDR, err := payment.Asset.MarshalBinary()
 		if err != nil {
 			log.Fatalf("error marshaling asset to XDR %s: %s", payment.Asset.String(), err)
 			return
 		}
-		_, err = c.db.Exec(q, tx.ID, i, payment.Amount, assetXDR, false)
+		_, err = c.db.Exec(q, tx.ID, i, payment.Amount, assetXDR, recipientPubkey)
 		if err != nil {
 			log.Fatal("error recording peg-in tx: ", err)
 			return


### PR DESCRIPTION
The recipient specified in the memo field applies to all payment operations to the custodian contained in the tx, each of which becomes its own row in `pegs`.