### PR TITLE
slidechain: remove redundant hex encoding

### DIFF
--- a/slidechain/slidechain.go
+++ b/slidechain/slidechain.go
@@ -115,8 +115,7 @@ func main() {
 	if !ok {
 		log.Fatal("error converting custodian public key to byteslice")
 	}
-	pubkeyHex := hex.EncodeToString(pubkey)
-	issueProgSrc = fmt.Sprintf(issueProgFmt, pubkeyHex)
+	issueProgSrc = fmt.Sprintf(issueProgFmt, pubkey)
 	issueProg, err = asm.Assemble(issueProgSrc)
 	if err != nil {
 		log.Fatal(err)


### PR DESCRIPTION
The sprintf format directive being populated in `issueProgFmt` is `%x`, which does its own hex encoding of `[]byte`-typed arguments.