### PR TITLE
slidechain: vendor worizon/xlm from starlight

### DIFF
--- a/slidechain/cmd/peg/peg.go
+++ b/slidechain/cmd/peg/peg.go
@@ -7,11 +7,11 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/interstellar/starlight/worizon/xlm"
 	b "github.com/stellar/go/build"
 	"github.com/stellar/go/clients/horizon"
 	"github.com/stellar/go/keypair"
 	"github.com/stellar/go/xdr"
-	"i10r.io/worizon/xlm"
 )
 
 func main() {

--- a/slidechain/export.go
+++ b/slidechain/export.go
@@ -6,10 +6,10 @@ import (
 
 	"github.com/bobg/sqlutil"
 	"github.com/chain/txvm/errors"
+	"github.com/interstellar/starlight/worizon/xlm"
 	b "github.com/stellar/go/build"
 	"github.com/stellar/go/clients/horizon"
 	"github.com/stellar/go/xdr"
-	"i10r.io/worizon/xlm"
 )
 
 const baseFee = 100

--- a/slidechain/vendor/github.com/interstellar/starlight/worizon/xlm/GOLICENSE
+++ b/slidechain/vendor/github.com/interstellar/starlight/worizon/xlm/GOLICENSE
@@ -1,0 +1,27 @@
+Copyright (c) 2009 The Go Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/slidechain/vendor/github.com/interstellar/starlight/worizon/xlm/xlm.go
+++ b/slidechain/vendor/github.com/interstellar/starlight/worizon/xlm/xlm.go
@@ -1,0 +1,110 @@
+package xlm
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+var errInvalidHorizonStr = errors.New("invalid horizon balance string")
+
+// Amount represents a quantity of XLM as an int64 count of stroops.
+type Amount int64
+
+// Common amounts.
+//
+// To count the number of units in an Amount, divide:
+//   lumen := xlm.Lumen
+//   fmt.Print(int64(lumen/xlm.Stroop)) // prints 10000000
+//
+// To convert an integer number of units to an Amount, multiply:
+//   lumens := 10
+//   fmt.Print(xlm.Amount(lumens)*xlm.Lumen) // prints 10XLM
+const (
+	Stroop     Amount = 1
+	Microlumen        = 10 * Stroop
+	Millilumen        = 1000 * Microlumen
+	Lumen             = 1000 * Millilumen
+)
+
+func (n Amount) String() string {
+	sign, u := "", uint64(n)
+	neg := n < 0
+	if neg {
+		sign, u = "-", -u
+	}
+
+	var (
+		denom uint64
+		prec  int
+		unit  string
+	)
+
+	switch {
+	case u == 0:
+		return "0 XLM"
+	case u == 1:
+		return sign + "1 stroop"
+	case u < uint64(Microlumen): // print stroops
+		return fmt.Sprintf("%d stroops", n)
+	case u < uint64(Millilumen): // print microlumens
+		denom, prec, unit = 10, 1, "µXLM"
+	case u < uint64(Lumen): // print millilumens
+		denom, prec, unit = 10000, 4, "mXLM"
+	default:
+		denom, prec, unit = 10000000, 7, "XLM"
+	}
+
+	whole, frac := u/denom, u%denom
+	return fmt.Sprintf("%s%d%s %s", sign, whole, fmtFrac(frac, prec), unit)
+}
+
+// HorizonString returns the Amount in decimal form in terms of Lumens,
+// required for building transactions to be submitted to Horizon.
+func (n Amount) HorizonString() string {
+	sign, coeff := "", 1
+	if n < 0 {
+		sign, coeff = "-", -1
+	}
+	u := uint64(Amount(coeff) * n)
+	denom := uint64(10000000)
+	whole, frac := u/denom, u%denom
+	return fmt.Sprintf("%s%d%s", sign, whole, fmtFrac(frac, 7))
+}
+
+// Parse converts a Horizon balance string to an Amount.
+func Parse(horizonString string) (Amount, error) {
+	splits := strings.Split(horizonString, ".")
+	if len(splits) > 2 || len(splits) == 0 {
+		return 0, errInvalidHorizonStr
+	}
+	intPart, err := strconv.ParseInt(splits[0], 10, 64)
+	if err != nil {
+		return 0, errInvalidHorizonStr
+	}
+	if len(splits) == 1 {
+		return Lumen * Amount(intPart), nil
+	}
+
+	if len(splits[1]) > 7 {
+		return 0, errInvalidHorizonStr
+	}
+	// Right-pad the fractional part of Horizon balance to be the
+	// correct number of Stroops.
+	fracPartStr := splits[1] + strings.Repeat("0", 7-len(splits[1]))
+	amountStr := splits[0] + fracPartStr
+	amount, err := strconv.ParseInt(amountStr, 10, 64)
+	if err != nil {
+		return 0, errInvalidHorizonStr
+	}
+	return Amount(amount), nil
+}
+
+func fmtFrac(u uint64, prec int) string {
+	if u == 0 {
+		return ""
+	}
+	s := fmt.Sprintf(".%0*d", prec, u)
+	return strings.TrimRight(s, "0")
+}

--- a/slidechain/vendor/modules.txt
+++ b/slidechain/vendor/modules.txt
@@ -33,6 +33,7 @@ github.com/go-errors/errors
 github.com/golang/protobuf/proto
 # github.com/interstellar/starlight v0.1.0-alpha
 github.com/interstellar/starlight/net
+github.com/interstellar/starlight/worizon/xlm
 github.com/interstellar/starlight/env
 # github.com/lib/pq v1.0.0
 github.com/lib/pq


### PR DESCRIPTION
Fixes Travis error by vendorizing the `worizon/xlm` package from the public Starlight repo.