### PR TITLE
slidechain: allow partial export of imported funds

### DIFF
--- a/slidechain/import.go
+++ b/slidechain/import.go
@@ -140,8 +140,7 @@ func (c *Custodian) doImport(ctx context.Context, txid string, opNum int, amount
 		return errors.Wrap(err, "submitting import tx")
 	}
 	txresult := txresult.New(importTx)
-	log.Printf("asset id: %x", txresult.Issuances[0].Value.AssetID)
-	log.Printf("output anchor: %x", txresult.Outputs[0].Value.Anchor)
+	log.Printf("assetID %x amount %d anchor %x\n", txresult.Issuances[0].Value.AssetID.Bytes(), txresult.Issuances[0].Value.Amount, txresult.Issuances[0].Value.Anchor)
 	_, err = c.DB.ExecContext(ctx, `UPDATE pegs SET imported=1 WHERE txid = $1 AND operation_num = $2`, txid, opNum)
 	return errors.Wrapf(err, "setting imported=1 for txid %s, operation %d", txid, opNum)
 }

--- a/slidechain/slidechain_test.go
+++ b/slidechain/slidechain_test.go
@@ -332,7 +332,7 @@ func TestEndToEnd(t *testing.T) {
 		}
 
 		// Build + submit export tx
-		exportTx, err := BuildExportTx(ctx, native, int64(amount), kp.Address(), anchor, recipientPrv)
+		exportTx, err := BuildExportTx(ctx, native, int64(amount), int64(amount), kp.Address(), anchor, recipientPrv)
 		if err != nil {
 			t.Fatalf("error building retirement tx %s", err)
 		}
@@ -376,7 +376,7 @@ func TestEndToEnd(t *testing.T) {
 					t.Fatalf("incorrect payment destination got %s, want %s", paymentOp.Destination.Address(), kp.Address())
 				}
 				if paymentOp.Amount != xdr.Int64(amount) {
-					t.Fatalf("got incorrect payment amount %d, want %d", paymentOp.Amount, 50)
+					t.Fatalf("got incorrect payment amount %d, want %d", paymentOp.Amount, amount)
 				}
 				if paymentOp.Asset.Type != xdr.AssetTypeAssetTypeNative {
 					t.Fatalf("got incorrect payment asset %s, want lumens", paymentOp.Asset.String())


### PR DESCRIPTION
Allows the user to use the `export` command to only export part of the imported funds, outputting the rest back to the original account. 