### PR TITLE
slidechain: add txvm programs for import uniqueness

### DIFF
--- a/slidechain/unique.go
+++ b/slidechain/unique.go
@@ -8,6 +8,9 @@ import (
 )
 
 const (
+	// createTokenProg creates a uniqueness token and is run before submitting the peg-in transaction to the Stellar network.
+	// It expects the following arg stack: asset, amount, zeroval, {recip}, quorum
+	// It moves them onto the contract stack and then `output`s a contract that runs a consumeToken when next called.
 	createTokenFmt = `
 	                        #  con stack                                                        arg stack                                log
 	                        #  ---------                                                        ---------                                ---
@@ -17,6 +20,10 @@ const (
 	output                  #  quorum, {recip}, zeroval, amount, asset                                                                   {"O", vm.caller, outputid}  
 `
 
+	// consumeTokenProg consumes said token and thus ensures that the import for a specific peg-in can only happen once.
+	// It expects the following con stack: quorum, {recip}, zeroval, amount, asset
+	// It confirms that its caller's seed is that of the import-issuance program.
+	// It then moves the con stack's arguments to the arg stack for the import-issuance transaction.
 	consumeTokenFmt = `
 	                     #  con stack                                                                arg stack                                log
 	                     #  ---------                                                                ---------                                ---
@@ -27,6 +34,11 @@ const (
 	put put put put put  #                                                                           asset, amount, zeroval, {recip}, quorum             
 `
 
+	// importIssuanceProg calls consumeTokenProg and a signature checker to produce various arguments for the import transaction.
+	// It expects the following arg stack: consumeTokenContract
+	// It calls that contract and gets its resulting arguments onto the con stack.
+	// It then creates a contract to check the custodian's signature and puts it on the arg stack.
+	// It then issues the pegged-in value and puts it, with other needed arguments for the import transaction, on the arg stack.
 	importIssuanceFmt = `
 	                                                    #  con stack                                arg stack                                log
 	                                                    #  ---------                                ---------                                ---


### PR DESCRIPTION
Adds TxVM programs to guarantee uniqueness of pegged-in Stellar transactions and their corresponding imports on TxVM. The `createTokenProg` creates a uniqueness token and is run before submitting the peg-in transaction to the Stellar network. The `consumeTokenProg` consumes said token and thus ensures that the import for a specific peg-in can only happen once. The `importIssuanceProg` calls the `consumeTokenProg`'s contract to produce various arguments for the import transaction and is described in more detail [here](https://github.com/interstellar/slingshot/blob/main/slidechain/Pegging.md#importing). Note that this PR does not explicitly call or submit these transactions; including these changes into the greater import workflow is left for a future PR.

https://trello.com/c/SnZp7YD3, 1-3