### PR TITLE
slidechain: use preauth tx as signer on pre-export tx

### DIFF
--- a/slidechain/cmd/export/export.go
+++ b/slidechain/cmd/export/export.go
@@ -111,7 +111,7 @@ func main() {
 	if err != nil {
 		log.Fatalf("error unmarshaling custodian account id: %s", err)
 	}
-	temp, seqnum, err := slidechain.SubmitPreExportTx(hclient, kp, custodian.Address(), asset, int(exportAmount))
+	temp, seqnum, err := slidechain.SubmitPreExportTx(hclient, kp, custodian.Address(), asset, exportAmount)
 	if err != nil {
 		log.Fatalf("error submitting pre-export tx: %s", err)
 	}

--- a/slidechain/export_test.go
+++ b/slidechain/export_test.go
@@ -52,7 +52,7 @@ func TestPegOut(t *testing.T) {
 		t.Fatalf("error funding account %s: %s", kp.Address(), err)
 	}
 
-	temp, seqnum, err := SubmitPreExportTx(c.hclient, kp, c.AccountID.Address(), lumen, amount)
+	temp, seqnum, err := SubmitPreExportTx(c.hclient, kp, c.AccountID.Address(), lumen, int64(amount))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/slidechain/slidechain_test.go
+++ b/slidechain/slidechain_test.go
@@ -339,7 +339,7 @@ func TestEndToEnd(t *testing.T) {
 		}
 
 		t.Log("submitting pre-export tx...")
-		temp, seqnum, err := SubmitPreExportTx(hclient, exporter, c.AccountID.Address(), native, int(amount))
+		temp, seqnum, err := SubmitPreExportTx(hclient, exporter, c.AccountID.Address(), native, int64(amount))
 		if err != nil {
 			t.Fatalf("pre-submit tx error: %s", err)
 		}


### PR DESCRIPTION
Per the updates to the peg-out protocol (#49), this changes the pre-export transaction to use a preauth tx as its sole signer, with the preauth tx being the one responsible for handling account merging and the payment of peg-out funds. 

Does not implement the suggested txvm contract to handle a loss-of-funds scenario of the destination account no longer exists or lacks the appropriate trustline.