### PR TITLE
zkvm: use newer merlin api

### DIFF
--- a/zkvm/src/blockchain/block.rs
+++ b/zkvm/src/blockchain/block.rs
@@ -1,4 +1,3 @@
-use core::borrow::Borrow;
 use merlin::Transcript;
 
 use super::super::utreexo;
@@ -44,13 +43,13 @@ impl BlockHeader {
     /// Computes the ID of the block header.
     pub fn id(&self) -> BlockID {
         let mut t = Transcript::new(b"ZkVM.blockheader");
-        t.commit_u64(b"version", self.version);
-        t.commit_u64(b"height", self.height);
-        t.commit_bytes(b"previd", &self.prev.0);
-        t.commit_u64(b"timestamp_ms", self.timestamp_ms);
-        t.commit_bytes(b"txroot", &self.txroot);
-        t.commit_bytes(b"utxoroot", &self.utxoroot);
-        t.commit_bytes(b"ext", &self.ext);
+        t.append_u64(b"version", self.version);
+        t.append_u64(b"height", self.height);
+        t.append_message(b"previd", &self.prev.0);
+        t.append_u64(b"timestamp_ms", self.timestamp_ms);
+        t.append_message(b"txroot", &self.txroot);
+        t.append_message(b"utxoroot", &self.utxoroot);
+        t.append_message(b"ext", &self.ext);
 
         let mut result = [0u8; 32];
         t.challenge_bytes(b"id", &mut result);

--- a/zkvm/src/blockchain/tests.rs
+++ b/zkvm/src/blockchain/tests.rs
@@ -55,7 +55,7 @@ fn test_state_machine() {
         let utx = Prover::build_tx(program, header, &bp_gens).unwrap();
 
         let mut signtx_transcript = Transcript::new(b"ZkVM.signtx");
-        signtx_transcript.commit_bytes(b"txid", &utx.txid.0);
+        signtx_transcript.append_message(b"txid", &utx.txid.0);
 
         let sig = Signature::sign_multi(
             &[privkey],

--- a/zkvm/src/contract.rs
+++ b/zkvm/src/contract.rs
@@ -158,7 +158,7 @@ impl Anchor {
     /// Ratchet the anchor into a new anchor
     pub fn ratchet(mut self) -> Self {
         let mut t = Transcript::new(b"ZkVM.ratchet-anchor");
-        t.commit_bytes(b"old", &self.0);
+        t.append_message(b"old", &self.0);
         t.challenge_bytes(b"new", &mut self.0);
         self
     }
@@ -172,7 +172,7 @@ impl ContractID {
 
     fn from_serialized_contract(bytes: &[u8]) -> Self {
         let mut t = Transcript::new(b"ZkVM.contractid");
-        t.commit_bytes(b"contract", bytes);
+        t.append_message(b"contract", bytes);
         let mut id = [0u8; 32];
         t.challenge_bytes(b"id", &mut id);
         Self(id)
@@ -242,6 +242,6 @@ impl PortableItem {
 
 impl MerkleItem for ContractID {
     fn commit(&self, t: &mut Transcript) {
-        t.commit_bytes(b"contract", self.as_bytes());
+        t.append_message(b"contract", self.as_bytes());
     }
 }

--- a/zkvm/src/merkle.rs
+++ b/zkvm/src/merkle.rs
@@ -73,13 +73,13 @@ impl MerkleTree {
             let mut t = transcript.clone();
             match node {
                 MerkleNeighbor::Left(l) => {
-                    t.commit_bytes(b"L", l);
-                    t.commit_bytes(b"R", &result);
+                    t.append_message(b"L", l);
+                    t.append_message(b"R", &result);
                     t.challenge_bytes(b"merkle.node", &mut result);
                 }
                 MerkleNeighbor::Right(r) => {
-                    t.commit_bytes(b"L", &result);
-                    t.commit_bytes(b"R", r);
+                    t.append_message(b"L", &result);
+                    t.append_message(b"R", r);
                     t.challenge_bytes(b"merkle.node", &mut result);
                 }
             }
@@ -125,8 +125,8 @@ impl MerkleTree {
                 let mut node = [0u8; 32];
                 let left = Self::build_tree(t.clone(), &list[..k]);
                 let right = Self::build_tree(t.clone(), &list[k..]);
-                t.commit_bytes(b"L", left.hash());
-                t.commit_bytes(b"R", right.hash());
+                t.append_message(b"L", left.hash());
+                t.append_message(b"R", right.hash());
                 t.challenge_bytes(b"merkle.node", &mut node);
                 MerkleNode::Node(node, Box::new(left), Box::new(right))
             }
@@ -186,7 +186,7 @@ mod tests {
 
     impl MerkleItem for TestItem {
         fn commit(&self, t: &mut Transcript) {
-            t.commit_u64(b"item", self.0)
+            t.append_u64(b"item", self.0)
         }
     }
 

--- a/zkvm/src/predicate.rs
+++ b/zkvm/src/predicate.rs
@@ -129,8 +129,8 @@ impl Predicate {
 
     fn commit_taproot(key: &VerificationKey, root: &[u8; 32]) -> Scalar {
         let mut t = Transcript::new(b"ZkVM.taproot");
-        t.commit_bytes(b"key", &key.as_compressed().to_bytes());
-        t.commit_bytes(b"merkle", root);
+        t.append_message(b"key", &key.as_compressed().to_bytes());
+        t.append_message(b"merkle", root);
         t.challenge_scalar(b"h")
     }
 
@@ -234,11 +234,11 @@ impl PredicateTree {
     fn create_merkle_leaves(progs: &Vec<Program>, blinding_key: [u8; 32]) -> Vec<PredicateLeaf> {
         let mut t = Transcript::new(b"ZkVM.taproot-derive-blinding");
         let n: u64 = progs.len() as u64;
-        t.commit_u64(b"n", n);
-        t.commit_bytes(b"key", &blinding_key);
+        t.append_u64(b"n", n);
+        t.append_message(b"key", &blinding_key);
         for prog in progs.iter() {
-            let mut buf = prog.encode_to_vec();
-            t.commit_bytes(b"prog", &buf);
+            let buf = prog.encode_to_vec();
+            t.append_message(b"prog", &buf);
         }
 
         let mut leaves = Vec::new();
@@ -338,7 +338,7 @@ impl MerkleItem for PredicateLeaf {
     fn commit(&self, t: &mut Transcript) {
         match self {
             PredicateLeaf::Program(prog) => prog.commit(t),
-            PredicateLeaf::Blinding(bytes) => t.commit_bytes(b"blinding", &bytes.clone()),
+            PredicateLeaf::Blinding(bytes) => t.append_message(b"blinding", &bytes.clone()),
         }
     }
 }

--- a/zkvm/src/program.rs
+++ b/zkvm/src/program.rs
@@ -203,13 +203,13 @@ impl MerkleItem for ProgramItem {
     fn commit(&self, t: &mut Transcript) {
         match self {
             ProgramItem::Program(prog) => prog.commit(t),
-            ProgramItem::Bytecode(bytes) => t.commit_bytes(b"program", &bytes),
+            ProgramItem::Bytecode(bytes) => t.append_message(b"program", &bytes),
         }
     }
 }
 
 impl MerkleItem for Program {
     fn commit(&self, t: &mut Transcript) {
-        t.commit_bytes(b"program", &self.to_bytes());
+        t.append_message(b"program", &self.to_bytes());
     }
 }

--- a/zkvm/src/prover.rs
+++ b/zkvm/src/prover.rs
@@ -110,7 +110,7 @@ impl<'t, 'g> Prover<'t, 'g> {
         let (txid, txlog) = vm.run()?;
 
         // Commit txid so that the proof is bound to the entire transaction, not just the constraint system.
-        prover.cs.transcript().commit_bytes(b"ZkVM.txid", &txid.0);
+        prover.cs.transcript().append_message(b"ZkVM.txid", &txid.0);
 
         // Generate the R1CS proof
         let proof = prover

--- a/zkvm/src/transcript.rs
+++ b/zkvm/src/transcript.rs
@@ -17,11 +17,11 @@ pub trait TranscriptProtocol {
 
 impl TranscriptProtocol for Transcript {
     fn commit_scalar(&mut self, label: &'static [u8], scalar: &Scalar) {
-        self.commit_bytes(label, scalar.as_bytes());
+        self.append_message(label, scalar.as_bytes());
     }
 
     fn commit_point(&mut self, label: &'static [u8], point: &CompressedRistretto) {
-        self.commit_bytes(label, point.as_bytes());
+        self.append_message(label, point.as_bytes());
     }
 
     fn challenge_scalar(&mut self, label: &'static [u8]) -> Scalar {

--- a/zkvm/src/tx.rs
+++ b/zkvm/src/tx.rs
@@ -214,7 +214,7 @@ impl<'de> Deserialize<'de> for Tx {
 
 impl MerkleItem for TxID {
     fn commit(&self, t: &mut Transcript) {
-        t.commit_bytes(b"txid", &self.0)
+        t.append_message(b"txid", &self.0)
     }
 }
 
@@ -229,9 +229,9 @@ impl MerkleItem for TxEntry {
     fn commit(&self, t: &mut Transcript) {
         match self {
             TxEntry::Header(h) => {
-                t.commit_u64(b"tx.version", h.version);
-                t.commit_u64(b"tx.mintime", h.mintime_ms);
-                t.commit_u64(b"tx.maxtime", h.maxtime_ms);
+                t.append_u64(b"tx.version", h.version);
+                t.append_u64(b"tx.mintime", h.mintime_ms);
+                t.append_u64(b"tx.maxtime", h.maxtime_ms);
             }
             TxEntry::Issue(q, f) => {
                 t.commit_point(b"issue.q", q);
@@ -242,13 +242,13 @@ impl MerkleItem for TxEntry {
                 t.commit_point(b"retire.f", f);
             }
             TxEntry::Input(contract) => {
-                t.commit_bytes(b"input", contract.as_bytes());
+                t.append_message(b"input", contract.as_bytes());
             }
             TxEntry::Output(contract) => {
-                t.commit_bytes(b"output", contract.id().as_bytes());
+                t.append_message(b"output", contract.id().as_bytes());
             }
             TxEntry::Data(data) => {
-                t.commit_bytes(b"data", data);
+                t.append_message(b"data", data);
             }
         }
     }

--- a/zkvm/src/types.rs
+++ b/zkvm/src/types.rs
@@ -275,8 +275,8 @@ impl Value {
     /// Computes a flavor as defined by the `issue` instruction from a predicate.
     pub fn issue_flavor(predicate: &Predicate, metadata: Data) -> Scalar {
         let mut t = Transcript::new(b"ZkVM.issue");
-        t.commit_bytes(b"predicate", predicate.to_point().as_bytes());
-        t.commit_bytes(b"metadata", &metadata.to_bytes());
+        t.append_message(b"predicate", predicate.to_point().as_bytes());
+        t.append_message(b"metadata", &metadata.to_bytes());
         t.challenge_scalar(b"flavor")
     }
 

--- a/zkvm/src/utreexo/nodes.rs
+++ b/zkvm/src/utreexo/nodes.rs
@@ -106,8 +106,8 @@ impl<M: MerkleItem> NodeHasher<M> {
 
     pub(super) fn intermediate(&self, left: &Hash, right: &Hash) -> Hash {
         let mut t = self.t.clone();
-        t.commit_bytes(b"L", left);
-        t.commit_bytes(b"R", right);
+        t.append_message(b"L", left);
+        t.append_message(b"R", right);
         let mut hash = [0; 32];
         t.challenge_bytes(b"merkle.node", &mut hash);
         hash

--- a/zkvm/src/utreexo/tests.rs
+++ b/zkvm/src/utreexo/tests.rs
@@ -5,7 +5,7 @@ use crate::merkle::*;
 
 impl MerkleItem for u64 {
     fn commit(&self, t: &mut Transcript) {
-        t.commit_u64(b"test_item", *self);
+        t.append_u64(b"test_item", *self);
     }
 }
 

--- a/zkvm/src/verifier.rs
+++ b/zkvm/src/verifier.rs
@@ -109,7 +109,10 @@ impl<'t> Verifier<'t> {
         let (txid, txlog) = vm.run()?;
 
         // Commit txid so that the proof is bound to the entire transaction, not just the constraint system.
-        verifier.cs.transcript().append_message(b"ZkVM.txid", &txid.0);
+        verifier
+            .cs
+            .transcript()
+            .append_message(b"ZkVM.txid", &txid.0);
 
         // Verify the R1CS proof
         verifier

--- a/zkvm/src/verifier.rs
+++ b/zkvm/src/verifier.rs
@@ -109,7 +109,7 @@ impl<'t> Verifier<'t> {
         let (txid, txlog) = vm.run()?;
 
         // Commit txid so that the proof is bound to the entire transaction, not just the constraint system.
-        verifier.cs.transcript().commit_bytes(b"ZkVM.txid", &txid.0);
+        verifier.cs.transcript().append_message(b"ZkVM.txid", &txid.0);
 
         // Verify the R1CS proof
         verifier
@@ -119,7 +119,7 @@ impl<'t> Verifier<'t> {
 
         // Verify the signatures over txid
         let mut signtx_transcript = Transcript::new(b"ZkVM.signtx");
-        signtx_transcript.commit_bytes(b"txid", &txid.0);
+        signtx_transcript.append_message(b"txid", &txid.0);
 
         if verifier.signtx_items.len() != 0 {
             verifier.deferred_operations.push(

--- a/zkvm/src/vm.rs
+++ b/zkvm/src/vm.rs
@@ -10,7 +10,6 @@ use std::mem;
 
 use crate::constraints::{Commitment, Constraint, Expression, Variable};
 use crate::contract::{Anchor, Contract, ContractID, PortableItem};
-use crate::encoding::Encodable;
 use crate::encoding::SliceReader;
 use crate::errors::VMError;
 use crate::ops::Instruction;
@@ -585,8 +584,8 @@ where
 
         // Verify signature using Verification key, over the message `program`
         let mut t = Transcript::new(b"ZkVM.delegate");
-        t.commit_bytes(b"contract", contract_id.as_ref());
-        t.commit_bytes(b"prog", &prog.to_bytes());
+        t.append_message(b"contract", contract_id.as_ref());
+        t.append_message(b"prog", &prog.to_bytes());
         self.delegate
             .verify_point_op(|| signature.verify(&mut t, verification_key).into())?;
 

--- a/zkvm/tests/zkvm.rs
+++ b/zkvm/tests/zkvm.rs
@@ -141,7 +141,7 @@ fn build_and_verify(program: Program, keys: &Vec<Scalar>) -> Result<TxID, VMErro
                 .collect();
 
             let mut signtx_transcript = Transcript::new(b"ZkVM.signtx");
-            signtx_transcript.commit_bytes(b"txid", &utx.txid.0);
+            signtx_transcript.append_message(b"txid", &utx.txid.0);
             Signature::sign_multi(
                 privkeys,
                 utx.signing_instructions.clone(),


### PR DESCRIPTION
Also eliminates a couple of unused imports to silence all compiler warnings.