### PR TITLE
zkvm|musig|keytree|token: remove use of Merlin deprecated APIs

### DIFF
--- a/keytree/keytree.md
+++ b/keytree/keytree.md
@@ -98,14 +98,14 @@ This applies to both Xpubs and Xprvs.
 2. If you are deriving from a parent Xprv, [create its corresponding parent Xpub first](#convert-xprv-to-xpub).
 3. Commit [xpub](#xpub) to the transcript:
 	```
-	prf.commit_bytes("pt", xpub.point)
-	prf.commit_bytes("dk", xpub.dk)
+	prf.append("pt", xpub.point)
+	prf.append("dk", xpub.dk)
 	```
 4. Provide the transcript to the user to commit an arbitrary derivation path or index:
 	```
-	prf.commit_bytes(label, data)
+	prf.append(label, data)
 	```
-	E.g. `prf.commit_u64("account", account_id)` for an account within a hierarchy of keys.
+	E.g. `prf.append_u64("account", account_id)` for an account within a hierarchy of keys.
 5. Squeeze a blinding factor `f`:
 	```
 	f = prf.challenge_scalar("f.intermediate")
@@ -131,14 +131,14 @@ Similar to the intermediate derivation, but for safety is domain-separated so th
 2. If you are deriving from a parent Xprv, [create its corresponding parent Xpub first](#convert-xprv-to-xpub).
 3. Commit [xpub](#xpub) to the provided key's PRF:
 	```
-	prf.commit_bytes("pt", xpub.point)
-	prf.commit_bytes("dk", xpub.dk)
+	prf.append("pt", xpub.point)
+	prf.append("dk", xpub.dk)
 	```
 4. Provide the transcript to the user to commit an arbitrary selector data (could be structured):
 	```
-	prf.commit_bytes(label, data)
+	prf.append(label, data)
 	```
-	E.g. `prf.commit_u64("invoice", invoice_index)` for a receiving address.
+	E.g. `prf.append_u64("invoice", invoice_index)` for a receiving address.
 5. Squeeze a blinding factor `f`:
 	```
 	f = prf.challenge_scalar("f.leaf")
@@ -160,17 +160,17 @@ Root keys:
 	R.Xprv: 00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
 	R.Xpub: 00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
 
-Derived intermediate children (`R->C`) with `PRF.commit("index", LE64(1))`:
+Derived intermediate children (`R->C`) with `PRF.append("index", LE64(1))`:
 
 	C.Xprv: ba9bead5df738767ca184900a4a09ce8afe9f7696e8d3ac1fd99f607a785bf005237586d5b496618a49a876e9a7e077b1715f8635b41b48edcaf2934ebe62683
 	C.Xpub: 2ec9d53d9d43b86c73694f4acd4be1c274a3cf8d7512e91acebafc0ed884dd475237586d5b496618a49a876e9a7e077b1715f8635b41b48edcaf2934ebe62683
 
-Derived intermediate grand-children (`C->G`) with `PRF.commit("index", LE64(1))`:
+Derived intermediate grand-children (`C->G`) with `PRF.append("index", LE64(1))`:
 	
 	G.Xprv: d4719a691dc4e97b27abfc50764d0369a197b3d03b049f0654d4872dd5f01f02f334cb814294776de8551a4e6382c14d05ad2eb6d6391e87069a3fbe2e6ecf77
 	G.Xpub: 1210a34624dfddb312da90ad5e2d3d4649d7eb50d44dad00972d1e1f422a4f29f334cb814294776de8551a4e6382c14d05ad2eb6d6391e87069a3fbe2e6ecf77
 
-Derived leaf keys from the intermediate children (`C->L`) with `PRF.commit("index", LE64(1))`:
+Derived leaf keys from the intermediate children (`C->L`) with `PRF.append("index", LE64(1))`:
 
 	L.Scalar: a7a8928dfeae1479a7bf908bfa929b714a62fe334b68e4557105414113ffca04
 	L.Point:  52ea0c9ce1540e65041565a1057aa6965bbb5b42709c1109da16609248a9d679

--- a/keytree/src/lib.rs
+++ b/keytree/src/lib.rs
@@ -155,7 +155,7 @@ impl Xpub {
     fn prepare_prf(&self) -> Transcript {
         let mut t = Transcript::new(b"Keytree.derivation");
         t.commit_point(b"pt", self.pubkey.as_compressed());
-        t.commit_bytes(b"dk", &self.dk);
+        t.append_message(b"dk", &self.dk);
         t
     }
 

--- a/keytree/src/tests.rs
+++ b/keytree/src/tests.rs
@@ -16,8 +16,8 @@ fn test_vectors() {
         "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
     );
 
-    let child_prv = root_prv.derive_intermediate_key(|prf| prf.commit_u64(b"index", 1));
-    let child_pub = root_pub.derive_intermediate_key(|prf| prf.commit_u64(b"index", 1));
+    let child_prv = root_prv.derive_intermediate_key(|prf| prf.append_u64(b"index", 1));
+    let child_pub = root_pub.derive_intermediate_key(|prf| prf.append_u64(b"index", 1));
     assert_eq!(
         to_hex_64(child_prv.to_bytes()),
         "ba9bead5df738767ca184900a4a09ce8afe9f7696e8d3ac1fd99f607a785bf005237586d5b496618a49a876e9a7e077b1715f8635b41b48edcaf2934ebe62683"
@@ -32,8 +32,8 @@ fn test_vectors() {
     );
 
     // Note: the leaf keys must be domain-separated from the intermediate keys, even if using the same PRF customization
-    let child2_prv = child_prv.derive_intermediate_key(|prf| prf.commit_u64(b"index", 1));
-    let child2_pub = child_pub.derive_intermediate_key(|prf| prf.commit_u64(b"index", 1));
+    let child2_prv = child_prv.derive_intermediate_key(|prf| prf.append_u64(b"index", 1));
+    let child2_pub = child_pub.derive_intermediate_key(|prf| prf.append_u64(b"index", 1));
     assert_eq!(
         to_hex_64(child2_prv.to_bytes()),
         "d4719a691dc4e97b27abfc50764d0369a197b3d03b049f0654d4872dd5f01f02f334cb814294776de8551a4e6382c14d05ad2eb6d6391e87069a3fbe2e6ecf77"
@@ -47,8 +47,8 @@ fn test_vectors() {
         "1210a34624dfddb312da90ad5e2d3d4649d7eb50d44dad00972d1e1f422a4f29f334cb814294776de8551a4e6382c14d05ad2eb6d6391e87069a3fbe2e6ecf77"
     );
 
-    let leaf_prv = child_prv.derive_key(|prf| prf.commit_u64(b"index", 1));
-    let leaf_pub = child_pub.derive_key(|prf| prf.commit_u64(b"index", 1));
+    let leaf_prv = child_prv.derive_key(|prf| prf.append_u64(b"index", 1));
+    let leaf_pub = child_pub.derive_key(|prf| prf.append_u64(b"index", 1));
     assert_eq!(
         hex::encode(leaf_prv.to_bytes()),
         "a7a8928dfeae1479a7bf908bfa929b714a62fe334b68e4557105414113ffca04"
@@ -114,7 +114,7 @@ fn random_xprv_derivation_test() {
     let seed = [0u8; 32];
     let mut rng = ChaChaRng::from_seed(seed);
     let xprv = Xprv::random(&mut rng).derive_intermediate_key(|prf| {
-        prf.commit_u64(b"account_id", 34);
+        prf.append_u64(b"account_id", 34);
     });
 
     assert_eq!(
@@ -136,7 +136,7 @@ fn random_xprv_leaf_test() {
     let seed = [0u8; 32];
     let mut rng = ChaChaRng::from_seed(seed);
     let xprv = Xprv::random(&mut rng).derive_key(|prf| {
-        prf.commit_u64(b"invoice_id", 10034);
+        prf.append_u64(b"invoice_id", 10034);
     });
 
     assert_eq!(
@@ -226,7 +226,7 @@ fn random_xpub_derivation_test() {
     let mut rng = ChaChaRng::from_seed(seed);
     let xprv = Xprv::random(&mut rng);
     let xpub = xprv.to_xpub().derive_intermediate_key(|prf| {
-        prf.commit_u64(b"account_id", 34);
+        prf.append_u64(b"account_id", 34);
     });
 
     assert_eq!(
@@ -245,7 +245,7 @@ fn random_xpub_leaf_test() {
     let mut rng = ChaChaRng::from_seed(seed);
     let xprv = Xprv::random(&mut rng);
     let pubkey = xprv.to_xpub().derive_key(|prf| {
-        prf.commit_u64(b"invoice_id", 10034);
+        prf.append_u64(b"invoice_id", 10034);
     });
 
     assert_eq!(

--- a/keytree/src/transcript.rs
+++ b/keytree/src/transcript.rs
@@ -15,7 +15,7 @@ pub trait TranscriptProtocol {
 
 impl TranscriptProtocol for Transcript {
     fn commit_point(&mut self, label: &'static [u8], point: &CompressedRistretto) {
-        self.commit_bytes(label, point.as_bytes());
+        self.append_message(label, point.as_bytes());
     }
 
     fn challenge_scalar(&mut self, label: &'static [u8]) -> Scalar {

--- a/musig/docs/musig-spec.md
+++ b/musig/docs/musig-spec.md
@@ -72,9 +72,9 @@ Transcripts have the following operations, each taking a label for domain separa
     ```
     T := Transcript(label)
     ```
-2. **Commit bytes** of arbitrary length:
+2. **Append bytes** of arbitrary length prefixed with a label:
     ```
-    T.commit(label, bytes)
+    T.append(label, bytes)
     ```
 3. **Challenge bytes**
     ```    
@@ -97,8 +97,8 @@ The protocol is the following:
 1. Prover and verifier obtain a [transcript](#transcript) `T` that is assumed to be already bound to the _message_ being signed.
 2. Prover and verifier both commit the verification key `X` (computed by the prover as `X = x·B`):
     ```
-    T.commit("dom-sep", "schnorr-signature v1")
-    T.commit("X", X)
+    T.append("dom-sep", "schnorr-signature v1")
+    T.append("X", X)
     ```
 3. Prover creates a _secret nonce_: a randomly sampled [scalar](#scalar) `r`.
 4. Prover commits to its nonce:
@@ -108,7 +108,7 @@ The protocol is the following:
 5. Prover sends `R` to the verifier.
 6. Prover and verifier write the nonce commitment `R` to the transcript:
     ```
-    T.commit("R", R)
+    T.append("R", R)
     ```
 7. Prover and verifier compute a Fiat-Shamir challenge scalar `c` using the transcript:
     ```
@@ -135,13 +135,13 @@ only their individual submessages, ignoring other signers’ submessages.
 1. Prover and verifier obtain a [transcript](#transcript) `T` that is assumed to be already bound to the _message_ being signed.
 2. Prover and verifier both commit the set of `n` verification keys `X[i]` and submessages `m[i]`:
     ```
-    T.commit("dom-sep", "schnorr-multi-signature v1")
-    T.commit_bytes("n", LE64(n))
-    T.commit_bytes("X", X[0])
-    T.commit_bytes("m", m[0])
+    T.append("dom-sep", "schnorr-multi-signature v1")
+    T.append("n", LE64(n))
+    T.append("X", X[0])
+    T.append("m", m[0])
     ...
-    T.commit_bytes("X", X[n-1])
-    T.commit_bytes("m", m[n-1])
+    T.append("X", X[n-1])
+    T.append("m", m[n-1])
     ```
 3. Prover creates a _secret nonce_: a randomly sampled [scalar](#scalar) `r`.
 4. Prover commits to its nonce:
@@ -151,12 +151,12 @@ only their individual submessages, ignoring other signers’ submessages.
 5. Prover sends `R` to the verifier.
 6. Prover and verifier write the nonce commitment `R` to the transcript:
     ```
-    T.commit("R", R)
+    T.append("R", R)
     ```
 7. Prover and verifier compute a Fiat-Shamir challenge scalar `e[i]` for each `i`th key, using the _copy_ of transcript `T`:
     ```
     T’ = copy(T)
-    T’.commit_bytes("i", LE64(i))
+    T’.append("i", LE64(i))
     c[i] = T’.challenge_scalar("c")
     ```
 8. Prover blinds the secret scalars `x[i]` using the nonce and the challenges `c[i]`:

--- a/musig/src/context.rs
+++ b/musig/src/context.rs
@@ -56,7 +56,7 @@ impl Multikey {
 
         // Create transcript for Multikey
         let mut prf = Transcript::new(b"Musig.aggregated-key");
-        prf.commit_u64(b"n", pubkeys.len() as u64);
+        prf.append_u64(b"n", pubkeys.len() as u64);
 
         // Commit pubkeys into the transcript
         // <L> = H(X_1 || X_2 || ... || X_n)
@@ -83,7 +83,7 @@ impl Multikey {
     /// a_i = H(<L>, X_i). The list of pubkeys, <L>, has already been committed to the transcript.
     fn compute_factor(prf: &Transcript, i: usize) -> Scalar {
         let mut a_i_prf = prf.clone();
-        a_i_prf.commit_u64(b"i", i as u64);
+        a_i_prf.append_u64(b"i", i as u64);
         a_i_prf.challenge_scalar(b"a_i")
     }
 
@@ -136,13 +136,13 @@ impl<M: AsRef<[u8]>> MusigContext for Multimessage<M> {
         transcript.schnorr_multisig_domain_sep(self.pairs.len());
         for (key, msg) in &self.pairs {
             transcript.commit_point(b"X", key.as_compressed());
-            transcript.commit_bytes(b"m", msg.as_ref());
+            transcript.append_message(b"m", msg.as_ref());
         }
     }
 
     fn challenge(&self, i: usize, transcript: &mut Transcript) -> Scalar {
         let mut transcript_i = transcript.clone();
-        transcript_i.commit_u64(b"i", i as u64);
+        transcript_i.append_u64(b"i", i as u64);
         transcript_i.challenge_scalar(b"c")
 
         // TBD: Do we want to add a domain separator to the transcript?

--- a/musig/src/signature.rs
+++ b/musig/src/signature.rs
@@ -25,7 +25,7 @@ impl Signature {
 
         let mut rng = transcript
             .build_rng()
-            .commit_witness_bytes(b"x", &privkey.to_bytes())
+            .rekey_with_witness_bytes(b"x", &privkey.to_bytes())
             .finalize(&mut rand::thread_rng());
 
         // Generate ephemeral keypair (r, R). r is a random nonce.
@@ -72,7 +72,7 @@ impl Signature {
             .build_rng()
             // Use one key that has enough entropy to seed the RNG.
             // We can call unwrap because we know that the privkeys length is > 0.
-            .commit_witness_bytes(b"x_i", privkeys.peek().unwrap().borrow().as_bytes())
+            .rekey_with_witness_bytes(b"x_i", privkeys.peek().unwrap().borrow().as_bytes())
             .finalize(&mut rand::thread_rng());
 
         // Generate ephemeral keypair (r, R). r is a random nonce.

--- a/musig/src/signer.rs
+++ b/musig/src/signer.rs
@@ -52,7 +52,7 @@ impl Signer {
     ) -> (SignerAwaitingPrecommitments<'t, C>, NoncePrecommitment) {
         let mut rng = transcript
             .build_rng()
-            .commit_witness_bytes(b"x_i", &x_i.to_bytes())
+            .rekey_with_witness_bytes(b"x_i", &x_i.to_bytes())
             .finalize(&mut rand::thread_rng());
 
         // Generate ephemeral keypair (r_i, R_i). r_i is a random nonce.

--- a/musig/src/transcript.rs
+++ b/musig/src/transcript.rs
@@ -21,18 +21,18 @@ pub trait TranscriptProtocol {
 
 impl TranscriptProtocol for Transcript {
     fn schnorr_sig_domain_sep(&mut self) {
-        self.commit_bytes(b"dom-sep", b"schnorr-signature v1");
+        self.append_message(b"dom-sep", b"schnorr-signature v1");
     }
     fn schnorr_multisig_domain_sep(&mut self, n: usize) {
-        self.commit_bytes(b"dom-sep", b"schnorr-multi-signature v1");
-        self.commit_u64(b"n", n as u64);
+        self.append_message(b"dom-sep", b"schnorr-multi-signature v1");
+        self.append_u64(b"n", n as u64);
     }
     fn commit_scalar(&mut self, label: &'static [u8], scalar: &Scalar) {
-        self.commit_bytes(label, scalar.as_bytes());
+        self.append_message(label, scalar.as_bytes());
     }
 
     fn commit_point(&mut self, label: &'static [u8], point: &CompressedRistretto) {
-        self.commit_bytes(label, point.as_bytes());
+        self.append_message(label, point.as_bytes());
     }
 
     fn challenge_scalar(&mut self, label: &'static [u8]) -> Scalar {

--- a/token/src/token.rs
+++ b/token/src/token.rs
@@ -160,7 +160,7 @@ mod tests {
             .collect();
 
         let mut signtx_transcript = Transcript::new(b"ZkVM.signtx");
-        signtx_transcript.commit_bytes(b"txid", &utx.txid.0);
+        signtx_transcript.append_message(b"txid", &utx.txid.0);
         let sig = Signature::sign_multi(
             privkeys,
             utx.signing_instructions.clone(),

--- a/zkvm/docs/utreexo.md
+++ b/zkvm/docs/utreexo.md
@@ -133,8 +133,8 @@ and then generating 32-byte challenge string the label `merkle.leaf`:
 
 ```
 MerkleHash(T, {item}) = {
-    T.commit(<field1 name>, item.field1)
-    T.commit(<field2 name>, item.field2)
+    T.append(<field1 name>, item.field1)
+    T.append(<field2 name>, item.field2)
     ...
     T.challenge_bytes("merkle.leaf")
 }
@@ -144,8 +144,8 @@ For `n > 1`, let `k` be the largest power of two smaller than `n` (i.e., `k < n 
 
 ```
 MerkleHash(T, list) = {
-    T.commit("L", MerkleHash(list[0..k]))
-    T.commit("R", MerkleHash(list[k..n]))
+    T.append("L", MerkleHash(list[0..k]))
+    T.append("R", MerkleHash(list[k..n]))
     T.challenge_bytes("merkle.node")
 }
 ```

--- a/zkvm/docs/zkvm-blockchain.md
+++ b/zkvm/docs/zkvm-blockchain.md
@@ -72,13 +72,13 @@ A block ID is computed from a [block header](#block-header) using the [transcrip
 
 ```
 T = Transcript("ZkVM.blockheader")
-T.commit("version", LE64(version))
-T.commit("height", LE64(height))
-T.commit("previd", previd)
-T.commit("timestamp_ms", LE64(timestamp_ms))
-T.commit("txroot", txroot)
-T.commit("utxoroot", utxoroot)
-T.commit("ext", ext)
+T.append("version", LE64(version))
+T.append("height", LE64(height))
+T.append("previd", previd)
+T.append("timestamp_ms", LE64(timestamp_ms))
+T.append("txroot", txroot)
+T.append("utxoroot", utxoroot)
+T.append("ext", ext)
 blockid = T.challenge_bytes("id")
 ```
 
@@ -87,7 +87,7 @@ blockid = T.challenge_bytes("id")
 [Contract ID](zkvm-spec.md#contract-id) is hashed as a [merkle leaf hash](utreexo.md#merkle-root) for the Utreexo as follows:
 
 ```
-T.commit("contract", contract_id)
+T.append("contract", contract_id)
 ```
 
 # Procedures


### PR DESCRIPTION
This replaces the use of deprecated methods in Merlin with better named methods.

Changes:
* `.commit_bytes()` to `.append_bytes()`
* `.commit_u64()` to `.append_u64()`
* `.commit_witness_bytes()` to `.rekey_with_witness_bytes()`
