### PR TITLE
zkvm: simplify contract API

### DIFF
--- a/zkvm/src/blockchain/tests.rs
+++ b/zkvm/src/blockchain/tests.rs
@@ -22,14 +22,14 @@ fn make_nonce_contract(privkey: u64, qty: u64) -> Contract {
     let mut anchor_bytes = [0u8; 32];
     rand::thread_rng().fill_bytes(&mut anchor_bytes);
 
-    Contract::new(
-        make_predicate(privkey),
-        vec![PortableItem::Value(Value {
+    Contract {
+        predicate: make_predicate(privkey),
+        payload: vec![PortableItem::Value(Value {
             qty: Commitment::unblinded(qty),
             flv: Commitment::unblinded(nonce_flavor()),
         })],
-        Anchor::from_raw_bytes(anchor_bytes),
-    )
+        anchor: Anchor::from_raw_bytes(anchor_bytes),
+    }
 }
 
 #[test]

--- a/zkvm/src/encoding.rs
+++ b/zkvm/src/encoding.rs
@@ -27,16 +27,6 @@ impl<'a> SliceReader<'a> {
         self.end - self.start
     }
 
-    pub fn slice<F, T>(&mut self, slice_fn: F) -> Result<(T, &[u8]), VMError>
-    where
-        F: FnOnce(&mut Self) -> Result<T, VMError>,
-    {
-        let start = self.start;
-        let result = slice_fn(self)?;
-        let end = self.start;
-        Ok((result, &self.whole[start..end]))
-    }
-
     pub fn parse<F, T>(data: &'a [u8], parse_fn: F) -> Result<T, VMError>
     where
         F: FnOnce(&mut Self) -> Result<T, VMError>,

--- a/zkvm/tests/zkvm.rs
+++ b/zkvm/tests/zkvm.rs
@@ -98,14 +98,14 @@ fn make_flavor() -> (Scalar, Predicate, Scalar) {
 
 /// Creates an Output contract with given quantity, flavor, and predicate.
 fn make_output(qty: u64, flv: Scalar, predicate: Predicate) -> Contract {
-    Contract::new(
+    Contract {
         predicate,
-        vec![PortableItem::Value(Value {
+        payload: vec![PortableItem::Value(Value {
             qty: Commitment::blinded(qty),
             flv: Commitment::blinded(flv),
         })],
-        Anchor::from_raw_bytes([0u8; 32]),
-    )
+        anchor: Anchor::from_raw_bytes([0u8; 32]),
+    }
 }
 
 fn build_and_verify(program: Program, keys: &Vec<Scalar>) -> Result<TxID, VMError> {


### PR DESCRIPTION
This patch removes premature optimization that keeps precomputed `ContractID`, which allows making the code and serialization simpler.