### PR TITLE
zkvm: more serde support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ matrix:
     script:
       - go test -v ./slidechain/... -timeout 60m
   - language: rust
-    rust: nightly-2018-12-31
+    rust: nightly-2019-07-31
     # per https://levans.fr/rust_travis_cache.html
     cache:
       directories:
@@ -35,7 +35,7 @@ matrix:
     - cargo test
     - RUSTFLAGS="-C opt-level=0" cargo bench "DONOTMATCHANYBENCHMARK"
   - language: rust
-    rust: nightly-2018-12-31
+    rust: nightly-2019-07-31
     # per https://levans.fr/rust_travis_cache.html
     cache:
       directories:
@@ -50,7 +50,7 @@ matrix:
     - cargo test
     - RUSTFLAGS="-C opt-level=0" cargo bench "DONOTMATCHANYBENCHMARK"
   - language: rust
-    rust: nightly-2018-12-31
+    rust: nightly-2019-07-31
     # per https://levans.fr/rust_travis_cache.html
     cache:
       directories:
@@ -65,7 +65,7 @@ matrix:
     - cargo test
     - RUSTFLAGS="-C opt-level=0" cargo bench "DONOTMATCHANYBENCHMARK"
   - language: rust
-    rust: nightly-2018-12-31
+    rust: nightly-2019-07-31
     # per https://levans.fr/rust_travis_cache.html
     cache:
       directories:
@@ -79,4 +79,18 @@ matrix:
     - cargo fmt --all -- --check
     - cargo test
     - RUSTFLAGS="-C opt-level=0" cargo bench "DONOTMATCHANYBENCHMARK"
-
+  - language: rust
+    rust: nightly-2019-07-31
+    # per https://levans.fr/rust_travis_cache.html
+    cache:
+      directories:
+        - /home/travis/.cargo
+    before_cache:
+      - rm -rf /home/travis/.cargo/registry
+    before_script:
+    - cd accounts
+    - rustup component add rustfmt-preview
+    script:
+    - cargo fmt --all -- --check
+    - cargo test
+    - RUSTFLAGS="-C opt-level=0" cargo bench "DONOTMATCHANYBENCHMARK"

--- a/accounts/Cargo.toml
+++ b/accounts/Cargo.toml
@@ -12,6 +12,7 @@ postgres = "0.15"
 rand = "0.6"
 subtle = "2"
 curve25519-dalek = { version = "1.0.1", features = ["serde"] }
+serde = { version = "1.0", features=["derive"] }
 
 [dependencies.bulletproofs]
 git = "https://github.com/dalek-cryptography/bulletproofs"

--- a/accounts/src/lib.rs
+++ b/accounts/src/lib.rs
@@ -64,9 +64,12 @@ Questions:
        so the sender can avoid publishing it unless recipient acknowledged the payment details.
 */
 
+use curve25519_dalek::ristretto::CompressedRistretto;
 use curve25519_dalek::scalar::Scalar;
 use keytree::{Xprv, Xpub};
 use merlin::Transcript;
+use musig::VerificationKey;
+use serde::{Deserialize, Serialize};
 use zkvm::{
     Anchor, ClearValue, Commitment, Contract, PortableItem, Predicate, TranscriptProtocol, Value,
 };
@@ -74,11 +77,12 @@ use zkvm::{
 #[cfg(test)]
 mod tests;
 
-#[derive(Copy, Clone, Eq, Hash, Debug, PartialEq, Default)]
+#[derive(Copy, Clone, Eq, Hash, Debug, PartialEq, Default, Serialize, Deserialize)]
+#[serde(transparent)]
 pub struct ReceiverID([u8; 32]);
 
 /// State of the account
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Account {
     /// Account's root extended public key.
     pub xpub: Xpub,
@@ -88,10 +92,10 @@ pub struct Account {
 }
 
 /// Receiver describes the destination for the payment.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Receiver {
     /// Address to which the payment must be sent.
-    pub predicate: Predicate,
+    pub opaque_predicate: CompressedRistretto,
 
     /// Cleartext amount of payment: qty and flavor.
     pub value: ClearValue,
@@ -104,7 +108,7 @@ pub struct Receiver {
 }
 
 /// Private annotation to the receiver that describes derivation path
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct ReceiverWitness {
     /// Account's sequence number at which this receiver was generated.
     pub sequence: u64,
@@ -114,7 +118,7 @@ pub struct ReceiverWitness {
 }
 
 /// Contains the anchor for the contract that allows computing the ContractID.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct ReceiverReply {
     /// ID of the receiver to which this info applies
     pub receiver_id: ReceiverID,
@@ -123,11 +127,33 @@ pub struct ReceiverReply {
     pub anchor: Anchor,
 }
 
+impl ReceiverWitness {
+    /// Returns `Predicate::Key`
+    pub fn predicate(&self) -> Predicate {
+        // If we have a witness object, we know that our predicate is
+        // (1) correct Ristretto point,
+        // (2) a simple public key.
+        // Therefore, we can simply unwrap.
+        // TBD: We can derive the pubkey on the fly
+        // with static guarantees of correctness.
+        Predicate::Key(VerificationKey::from_compressed(self.receiver.opaque_predicate).unwrap())
+    }
+
+    /// Creates a new contract for the given receiver and an anchor.
+    pub fn contract(&self, anchor: Anchor) -> Contract {
+        Contract {
+            predicate: self.predicate(),
+            payload: vec![PortableItem::Value(self.receiver.blinded_value())],
+            anchor,
+        }
+    }
+}
+
 impl Receiver {
     /// Returns the unique identifier of the receiver.
     pub fn id(&self) -> ReceiverID {
         let mut t = Transcript::new(b"ZkVM.accounts.receiver");
-        t.append_message(b"predicate", self.predicate.to_point().as_bytes());
+        t.append_message(b"predicate", self.opaque_predicate.as_bytes());
         t.append_u64(b"qty", self.value.qty);
         t.append_message(b"flv", self.value.flv.as_bytes());
         t.append_message(b"qty_blinding", self.qty_blinding.as_bytes());
@@ -137,21 +163,17 @@ impl Receiver {
         receiver
     }
 
+    /// Returns the predicate object.
+    pub fn predicate(&self) -> Predicate {
+        Predicate::Opaque(self.opaque_predicate)
+    }
+
     /// Constructs a value object from the qty, flavor and blinding factors.
     pub fn blinded_value(&self) -> Value {
         Value {
             qty: Commitment::blinded_with_factor(self.value.qty, self.qty_blinding),
             flv: Commitment::blinded_with_factor(self.value.flv, self.flv_blinding),
         }
-    }
-
-    /// Creates a new contract for the given receiver and an anchor.
-    pub fn contract(&self, anchor: Anchor) -> Contract {
-        Contract::new(
-            self.predicate.clone(),
-            vec![PortableItem::Value(self.blinded_value())],
-            anchor,
-        )
     }
 }
 
@@ -172,7 +194,7 @@ impl Account {
         ReceiverWitness {
             sequence: seq,
             receiver: Receiver {
-                predicate: Predicate::Key(key),
+                opaque_predicate: key.into_compressed(),
                 value,
                 qty_blinding,
                 flv_blinding,

--- a/accounts/src/tests.rs
+++ b/accounts/src/tests.rs
@@ -55,7 +55,7 @@ struct ConfirmedUtxo {
 }
 
 #[test]
-fn simple_tx() {
+fn basic_accounts_test() {
     let bp_gens = BulletproofGens::new(256, 1);
 
     // Overview:
@@ -149,10 +149,10 @@ fn simple_tx() {
 
             // Now the payment and the change are in the same order on the stack:
             // change is on top.
-            p.push(change_receiver_witness.receiver.predicate.clone());
+            p.push(change_receiver_witness.receiver.predicate());
             p.output(1);
 
-            p.push(payment_receiver.predicate.clone());
+            p.push(payment_receiver.predicate());
             p.output(1);
 
             // TBD: change the API to not require return of the `&mut program` from the closure.
@@ -173,7 +173,7 @@ fn simple_tx() {
 
     // Collect all anchors for outputs.
     let mut iterator = utx.txlog.iter().filter_map(|e| match e {
-        TxEntry::Output(contract) => Some(contract.anchor()),
+        TxEntry::Output(contract) => Some(contract.anchor),
         _ => None,
     });
     let change_anchor = iterator.next().unwrap();
@@ -361,7 +361,7 @@ impl AsRef<ClearValue> for ConfirmedUtxo {
 impl PendingUtxo {
     /// Convert utxo to a Contract instance
     fn contract(&self) -> Contract {
-        self.receiver_witness.receiver.contract(self.anchor)
+        self.receiver_witness.contract(self.anchor)
     }
 
     /// Returns the UTXO ID
@@ -382,7 +382,7 @@ impl PendingUtxo {
 impl ConfirmedUtxo {
     /// Convert utxo to a Contract instance
     fn contract(&self) -> Contract {
-        self.receiver_witness.receiver.contract(self.anchor)
+        self.receiver_witness.contract(self.anchor)
     }
 
     /// Returns the UTXO ID

--- a/keytree/Cargo.toml
+++ b/keytree/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2018"
 
 [dependencies]
 curve25519-dalek = { version = "1.0.1", features = ["serde"] }
+serde = { version = "1.0", features=["derive"] }
 merlin = "1.0.1"
 rand = "0.6"
 

--- a/keytree/src/lib.rs
+++ b/keytree/src/lib.rs
@@ -1,13 +1,15 @@
 #![deny(missing_docs)]
 //! Implementation of the key tree protocol, a key blinding scheme for deriving hierarchies of public keys.
 
-use crate::transcript::TranscriptProtocol;
 use curve25519_dalek::constants;
 use curve25519_dalek::ristretto::CompressedRistretto;
 use curve25519_dalek::scalar::Scalar;
 use merlin::Transcript;
 use musig::VerificationKey;
 use rand::{CryptoRng, RngCore};
+use serde::{Deserialize, Serialize};
+
+use crate::transcript::TranscriptProtocol;
 
 mod transcript;
 
@@ -15,14 +17,16 @@ mod transcript;
 mod tests;
 
 /// Xprv represents an extended private key.
-#[derive(Copy, Clone, PartialEq, Eq, Default, Debug)]
+/// TBD: change serialization to encode a single 64-byte blob, with hex for human-readable formats
+#[derive(Copy, Clone, PartialEq, Eq, Default, Debug, Serialize, Deserialize)]
 pub struct Xprv {
     scalar: Scalar,
     xpub: Xpub,
 }
 
 /// Xpub represents an extended public key.
-#[derive(Copy, Clone, PartialEq, Eq, Default, Debug)]
+/// TBD: change serialization to encode a single 64-byte blob, with hex for human-readable formats
+#[derive(Copy, Clone, PartialEq, Eq, Default, Debug, Serialize, Deserialize)]
 pub struct Xpub {
     pubkey: VerificationKey,
     dk: [u8; 32],

--- a/zkvm/src/blockchain/block.rs
+++ b/zkvm/src/blockchain/block.rs
@@ -1,15 +1,17 @@
 use merlin::Transcript;
+use serde::{Deserialize, Serialize};
 
 use super::super::utreexo;
 use crate::{MerkleTree, Tx, TxEntry, TxID, VerifiedTx};
 
 /// Identifier of the block, computed as a hash of the `BlockHeader`.
-#[derive(Clone, Copy, PartialEq, Debug)]
+#[derive(Clone, Copy, PartialEq, Debug, Serialize, Deserialize)]
+#[serde(transparent)]
 pub struct BlockID(pub [u8; 32]);
 
 /// BlockHeader contains the metadata for the block of transactions,
 /// committing to them, but not containing the actual transactions.
-#[derive(Clone, PartialEq, Debug)]
+#[derive(Clone, PartialEq, Debug, Serialize, Deserialize)]
 pub struct BlockHeader {
     /// Network version.
     pub version: u64,
@@ -29,7 +31,7 @@ pub struct BlockHeader {
 }
 
 /// Block is a collection of transactions.
-#[derive(Clone)]
+#[derive(Clone, Serialize, Deserialize)]
 pub struct Block {
     /// Block header.
     pub header: BlockHeader,

--- a/zkvm/src/contract.rs
+++ b/zkvm/src/contract.rs
@@ -20,11 +20,12 @@ pub const VALUE_TYPE: u8 = 0x02;
 
 /// A unique identifier for an anchor
 #[derive(Copy, Clone, Debug, Serialize, Deserialize)]
+#[serde(transparent)]
 pub struct Anchor(pub [u8; 32]);
 
 /// A unique identifier for a contract.
 #[derive(Copy, Clone, Eq, Hash, Debug, PartialEq, Default, Serialize, Deserialize)]
-#[serde(from=)]
+#[serde(transparent)]
 pub struct ContractID(pub [u8; 32]);
 
 /// A ZkVM contract that holds a _payload_ (a list of portable items) protected by a _predicate_.

--- a/zkvm/src/tx.rs
+++ b/zkvm/src/tx.rs
@@ -2,7 +2,7 @@ use bulletproofs::r1cs::R1CSProof;
 use curve25519_dalek::ristretto::CompressedRistretto;
 use merlin::Transcript;
 use musig::{Signature, VerificationKey};
-use serde::{self, Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 
 use crate::contract::{Contract, ContractID};
 use crate::encoding;

--- a/zkvm/src/types.rs
+++ b/zkvm/src/types.rs
@@ -3,6 +3,7 @@
 use bulletproofs::r1cs;
 use curve25519_dalek::scalar::Scalar;
 use merlin::Transcript;
+use serde::{Deserialize, Serialize};
 use spacesuit::SignedInteger;
 
 use crate::constraints::{Commitment, Constraint, Expression, Variable};
@@ -86,7 +87,7 @@ pub struct Value {
 /// Represents a cleartext value of an issued asset in the VM.
 /// This is not the same as `spacesuit::Value` since it is guaranteed to be in-range
 /// (negative quantity is not representable with this type).
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, Serialize, Deserialize)]
 pub struct ClearValue {
     /// Cleartext quantity integer
     pub qty: u64,

--- a/zkvm/src/utreexo/forest.rs
+++ b/zkvm/src/utreexo/forest.rs
@@ -1,8 +1,9 @@
-use crate::merkle::MerkleItem;
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
 use super::nodes::{Hash, Heap, Node, NodeHasher, NodeIndex};
 use super::path::{Directions, Path, Position, Proof};
+use crate::merkle::MerkleItem;
 
 /// Forest consists of a number of roots of merkle binary trees.
 /// Each forest is identified by a generation.

--- a/zkvm/src/utreexo/path.rs
+++ b/zkvm/src/utreexo/path.rs
@@ -1,4 +1,5 @@
 use crate::merkle::MerkleItem;
+use serde::{Deserialize, Serialize};
 
 use super::super::encoding::{self, Encodable};
 use super::nodes::{Hash, NodeHasher};
@@ -14,7 +15,7 @@ pub type Position = u64;
 /// (Lowest bit=1 means the first neighbor is to the left of the node.)
 /// `generation` points to the generation of the Forest to which the proof applies.
 /// `path` is None if this proof is for a newly added item that has no merkle path yet.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Proof {
     /// Generation of the forest to which the proof applies.
     pub generation: u64,
@@ -24,7 +25,7 @@ pub struct Proof {
 }
 
 /// Merkle path to the item.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Path {
     pub(super) position: Position,
     pub(super) neighbors: Vec<Hash>,


### PR DESCRIPTION
* `accounts`: add Travis CI entry.
* `accounts`: refactors Receiver API to support serialization.
* `keytree`: suboptimal serialization for Xpub/Xprv.
* `zkvm`: serialize blocks and utreexo proofs.

Next steps: serialize BlockchainState, utreexo Forest and Catchup.