### PR TITLE
zkvm: mempool implementation

### DIFF
--- a/accounts/src/tests.rs
+++ b/accounts/src/tests.rs
@@ -281,7 +281,10 @@ fn process_block(node: &mut Node, block: &Block, bp_gens: &BulletproofGens) {
                     .position(|utxo| utxo.contract_id() == cid)
                 {
                     let pending_utxo = node.wallet.pending_utxos.remove(i);
-                    let proof = new_state.catchup.update_proof(&cid, None, &hasher).unwrap();
+                    let proof = new_state
+                        .catchup
+                        .update_proof(&cid, utreexo::Proof::Transient, &hasher)
+                        .unwrap();
                     node.wallet.utxos.push(pending_utxo.to_confirmed(proof));
                 }
             }
@@ -297,7 +300,7 @@ fn process_block(node: &mut Node, block: &Block, bp_gens: &BulletproofGens) {
         .map(|utxo| {
             new_state
                 .catchup
-                .update_proof(&utxo.contract_id(), Some(utxo.proof.clone()), &hasher)
+                .update_proof(&utxo.contract_id(), utxo.proof.clone(), &hasher)
         })
         .collect::<Result<Vec<_>, _>>()
         .unwrap();

--- a/demo/src/nodes.rs
+++ b/demo/src/nodes.rs
@@ -243,7 +243,7 @@ impl Node {
                         {
                             let pending_utxo = self.wallet.pending_utxos.remove(i);
                             let proof =
-                                new_state.catchup.update_proof(&cid, None, &hasher).unwrap();
+                                new_state.catchup.update_proof(&cid, utreexo::Proof::Transient, &hasher).unwrap();
                             let new_utxo = pending_utxo.to_confirmed(proof);
                             self.wallet.utxos.push(new_utxo.clone());
                             known_outputs.push((entry_index, new_utxo));
@@ -272,7 +272,7 @@ impl Node {
             .map(|utxo| {
                 new_state.catchup.update_proof(
                     &utxo.contract_id(),
-                    Some(utxo.proof.clone()),
+                    utxo.proof.clone(),
                     &hasher,
                 )
             })

--- a/demo/src/nodes.rs
+++ b/demo/src/nodes.rs
@@ -242,8 +242,10 @@ impl Node {
                             .position(|utxo| utxo.contract_id() == cid)
                         {
                             let pending_utxo = self.wallet.pending_utxos.remove(i);
-                            let proof =
-                                new_state.catchup.update_proof(&cid, utreexo::Proof::Transient, &hasher).unwrap();
+                            let proof = new_state
+                                .catchup
+                                .update_proof(&cid, utreexo::Proof::Transient, &hasher)
+                                .unwrap();
                             let new_utxo = pending_utxo.to_confirmed(proof);
                             self.wallet.utxos.push(new_utxo.clone());
                             known_outputs.push((entry_index, new_utxo));
@@ -270,11 +272,9 @@ impl Node {
             .utxos
             .iter()
             .map(|utxo| {
-                new_state.catchup.update_proof(
-                    &utxo.contract_id(),
-                    utxo.proof.clone(),
-                    &hasher,
-                )
+                new_state
+                    .catchup
+                    .update_proof(&utxo.contract_id(), utxo.proof.clone(), &hasher)
             })
             .collect::<Result<Vec<_>, _>>()
             .unwrap();

--- a/demo/src/nodes.rs
+++ b/demo/src/nodes.rs
@@ -48,7 +48,7 @@ pub struct Wallet {
 /// Users convert pending utxos into ConfirmedUtxo when they detect the output in the blockchain.
 /// WARNING: this demo app makes an assumption that every unconfirmed tx is going to be published.
 /// This means:
-/// - mempool is cleared before app gets shut down - 
+/// - mempool is cleared before app gets shut down -
 ///   otherwise items marked as spent are going to be lost.
 ///   You should reset DB if you kill the app with non-empty mempool.
 /// - unconfirmed utxos are stored as spendable, even if it's not change, but incoming payment
@@ -205,8 +205,12 @@ impl Node {
 
         // Mark all spent utxos by removing them.
         for cid in contract_ids.iter() {
-            let i = self.wallet.utxos.iter().position(|o| o.contract_id() == *cid)
-            .expect("We just found utxos for spending, so we should find them again.");
+            let i = self
+                .wallet
+                .utxos
+                .iter()
+                .position(|o| o.contract_id() == *cid)
+                .expect("We just found utxos for spending, so we should find them again.");
             self.wallet.utxos.remove(i);
         }
         // save the change utxo - it is spendable right away, via a chain of unconfirmed txs.

--- a/demo/src/records.rs
+++ b/demo/src/records.rs
@@ -3,7 +3,7 @@ use super::schema::*;
 use super::util;
 use curve25519_dalek::scalar::Scalar;
 use zkvm::blockchain::{Block, BlockchainState};
-use zkvm::{Tx,TxEntry};
+use zkvm::{Tx, TxEntry};
 
 use serde_json::Value as JsonValue;
 use std::collections::HashMap;
@@ -63,7 +63,9 @@ impl BlockRecord {
     }
 
     pub fn tx_details(tx: &Tx) -> JsonValue {
-        let (txid, txlog) = tx.precompute().expect("Our blockchain does not have invalid transactions.");
+        let (txid, txlog) = tx
+            .precompute()
+            .expect("Our blockchain does not have invalid transactions.");
         json!({
             "id": hex::encode(&txid),
             "header": &util::to_json_value(&tx.header),

--- a/demo/src/schema.rs
+++ b/demo/src/schema.rs
@@ -20,8 +20,4 @@ table! {
     }
 }
 
-allow_tables_to_appear_in_same_query!(
-    asset_records,
-    block_records,
-    node_records,
-);
+allow_tables_to_appear_in_same_query!(asset_records, block_records, node_records,);

--- a/demo/src/schema.rs
+++ b/demo/src/schema.rs
@@ -20,4 +20,8 @@ table! {
     }
 }
 
-allow_tables_to_appear_in_same_query!(asset_records, block_records, node_records,);
+allow_tables_to_appear_in_same_query!(
+    asset_records,
+    block_records,
+    node_records,
+);

--- a/demo/templates/network/mempool.html.tera
+++ b/demo/templates/network/mempool.html.tera
@@ -11,53 +11,55 @@
     <tbody>
       <tr><th>Count</th><td>{{mempool_len}}</td></tr>
       <tr><th>Size</th><td>{{mempool_size_kb}} Kb</td></tr>
+      <tr>
+        <th></th>
+        <td>
+          <form class="col-6" action="/network/mempool/makeblock" method="POST" style="padding:0;margin:0;">
+            <button type="submit" class="btn btn-primary" style="min-width:130px">Make block</button>
+          </form>
+        </td>
+      </tr>
     </tbody>
   </table>
 
-  <!--
-  <div class="table-responsive">
-    <table class="table table-striped table-sm">
-      <thead>
-        <tr>
-          <th>#</th>
-          <th>Header</th>
-          <th>Header</th>
-          <th>Header</th>
-          <th>Header</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr>
-          <td>1,001</td>
-          <td>Lorem</td>
-          <td>ipsum</td>
-          <td>dolor</td>
-          <td>sit</td>
-        </tr>
-        <tr>
-          <td>1,013</td>
-          <td>torquent</td>
-          <td>per</td>
-          <td>conubia</td>
-          <td>nostra</td>
-        </tr>
-        <tr>
-          <td>1,014</td>
-          <td>per</td>
-          <td>inceptos</td>
-          <td>himenaeos</td>
-          <td>Curabitur</td>
-        </tr>
-        <tr>
-          <td>1,015</td>
-          <td>sodales</td>
-          <td>ligula</td>
-          <td>in</td>
-          <td>libero</td>
-        </tr>
-      </tbody>
-    </table>
+  <div class="d-flex justify-content-between flex-wrap flex-md-nowrap align-items-center pt-3 pb-2 mb-3">
+    <h3>Transactions</h3>
   </div>
-  -->
+
+  {% for tx in mempool_txs %}
+ 
+    <table class="table table-bordered block-header">
+    <tbody>
+      <tr><th>ID</th><td style="font-weight:bold"><tt>{{tx.id}}</tt></td></tr>
+      <tr><th>Version</th><td>{{tx.header.version}}</td></tr>
+      <tr><th>Time bounds</th><td>{{tx.header.mintime_ms}} — {{tx.header.maxtime_ms}}</td></tr>
+      <tr>
+        <th>Inputs</th>
+        <td><pre><code>{{tx.inputs | json_encode(pretty=true) }}</code></pre></td>
+      </tr>
+      <tr>
+        <th>Outputs</th>
+        <td><pre><code>{{tx.outputs | json_encode(pretty=true) }}</code></pre></td>
+      </tr>
+      <tr>
+        <th>Program</th>
+        <td><code>{{tx.program_asm}}</code></td>
+      </tr>
+      <tr>
+        <th>Raw program</th>
+        <td><code>{{tx.program_hex}}</code></td>
+      </tr>
+      <tr>
+        <th>Signature</th>
+        <td><code>{{tx.tx.signature}}</code></td>
+      </tr>
+      <tr>
+        <th>R1CS proof</th>
+        <td><code>{{tx.tx.proof}}</code></td>
+      </tr>
+    </tbody>
+    </table>
+
+  {% endfor %}
     
 {% endblock main %}

--- a/demo/templates/network/mempool.html.tera
+++ b/demo/templates/network/mempool.html.tera
@@ -9,8 +9,8 @@
 
   <table class="table xtable-bordered col-12 col-md-3">
     <tbody>
-      <tr><th>Count</th><td>TBD</td></tr>
-      <tr><th>Size</th><td>{TBD} Kb</td></tr>
+      <tr><th>Count</th><td>{{mempool_len}}</td></tr>
+      <tr><th>Size</th><td>{{mempool_size_kb}} Kb</td></tr>
     </tbody>
   </table>
 

--- a/zkvm/src/blockchain/block.rs
+++ b/zkvm/src/blockchain/block.rs
@@ -38,7 +38,7 @@ pub struct Block {
     /// List of transactions.
     pub txs: Vec<Tx>, // no Debug impl for R1CSProof yet
     /// UTXO proofs
-    pub all_utxo_proofs: Vec<Option<utreexo::Proof>>,
+    pub all_utxo_proofs: Vec<utreexo::Proof>,
 }
 
 /// VerifiedBlock contains a list of VerifiedTx.
@@ -85,8 +85,8 @@ impl Block {
     /// Returns an iterator of all utxo proofs for all transactions in a block.
     /// This interface allows us to optimize the representation of utxo proofs,
     /// while not affecting the validation logic.
-    pub fn utxo_proofs(&self) -> impl IntoIterator<Item = Option<&utreexo::Proof>> {
-        self.all_utxo_proofs.iter().map(|o| o.as_ref())
+    pub fn utxo_proofs(&self) -> impl IntoIterator<Item = &utreexo::Proof> {
+        self.all_utxo_proofs.iter()
     }
 }
 

--- a/zkvm/src/blockchain/block.rs
+++ b/zkvm/src/blockchain/block.rs
@@ -38,7 +38,7 @@ pub struct Block {
     /// List of transactions.
     pub txs: Vec<Tx>, // no Debug impl for R1CSProof yet
     /// UTXO proofs
-    pub all_utxo_proofs: Vec<utreexo::Proof>,
+    pub all_utxo_proofs: Vec<Option<utreexo::Proof>>,
 }
 
 /// VerifiedBlock contains a list of VerifiedTx.
@@ -85,8 +85,8 @@ impl Block {
     /// Returns an iterator of all utxo proofs for all transactions in a block.
     /// This interface allows us to optimize the representation of utxo proofs,
     /// while not affecting the validation logic.
-    pub fn utxo_proofs(&self) -> impl IntoIterator<Item = &utreexo::Proof> {
-        self.all_utxo_proofs.iter()
+    pub fn utxo_proofs(&self) -> impl IntoIterator<Item = Option<&utreexo::Proof>> {
+        self.all_utxo_proofs.iter().map(|o| o.as_ref())
     }
 }
 

--- a/zkvm/src/blockchain/block.rs
+++ b/zkvm/src/blockchain/block.rs
@@ -96,3 +96,16 @@ impl VerifiedBlock {
         self.txs.iter().flat_map(|tx| tx.log.iter())
     }
 }
+
+impl AsRef<[u8]> for BlockID {
+    fn as_ref(&self) -> &[u8] {
+        &self.0
+    }
+}
+
+impl core::ops::Deref for BlockID {
+    type Target = [u8];
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}

--- a/zkvm/src/blockchain/mempool.rs
+++ b/zkvm/src/blockchain/mempool.rs
@@ -39,6 +39,11 @@ impl Mempool {
             .sum()
     }
 
+    /// Returns a list of transactions
+    pub fn txs(&self) -> impl Iterator<Item = &Tx> {
+        self.txs.iter().map(|(tx, _, _)| tx)
+    }
+
     /// Returns the size of the mempool in number of transactions.
     pub fn len(&self) -> usize {
         self.txs.len()

--- a/zkvm/src/blockchain/mempool.rs
+++ b/zkvm/src/blockchain/mempool.rs
@@ -39,7 +39,7 @@ impl Mempool {
     pub fn append<P: Borrow<utreexo::Proof>>(
         &mut self,
         tx: Tx,
-        utxo_proofs: impl IntoIterator<Item = Option<P>>,
+        utxo_proofs: impl IntoIterator<Item = P>,
         bp_gens: &BulletproofGens,
     ) -> Result<TxID, BlockchainError> {
         let verified_tx = self

--- a/zkvm/src/blockchain/mempool.rs
+++ b/zkvm/src/blockchain/mempool.rs
@@ -39,7 +39,7 @@ impl Mempool {
     pub fn append<P: Borrow<utreexo::Proof>>(
         &mut self,
         tx: Tx,
-        utxo_proofs: impl IntoIterator<Item = P>,
+        utxo_proofs: impl IntoIterator<Item = Option<P>>,
         bp_gens: &BulletproofGens,
     ) -> Result<TxID, BlockchainError> {
         let verified_tx = self

--- a/zkvm/src/blockchain/mempool.rs
+++ b/zkvm/src/blockchain/mempool.rs
@@ -1,0 +1,52 @@
+//! In-memory transaction pool for transactions that are not yet in a block.
+
+use crate::utreexo;
+use crate::{Tx, TxID, VerifiedTx};
+use bulletproofs::BulletproofGens;
+use core::borrow::Borrow;
+
+use super::{BlockchainError, BlockchainState, ValidationContext};
+
+/// Implements a pool of unconfirmed (not-in-the-block) transactions.
+pub struct Mempool {
+    state: BlockchainState,
+    timestamp_ms: u64,
+    validation: ValidationContext,
+    txs: Vec<(Tx, VerifiedTx)>,
+}
+
+impl Mempool {
+    /// Creates an empty mempool at a given state.
+    pub fn new(state: BlockchainState, timestamp_ms: u64) -> Self {
+        let validation =
+            ValidationContext::new(state.tip.version, timestamp_ms, state.utreexo.work_forest());
+        Mempool {
+            state,
+            timestamp_ms,
+            validation,
+            txs: Vec::new(),
+        }
+    }
+
+    /// Clears mempool
+    pub fn reset(&mut self) {
+        let work_forest = self.state.utreexo.work_forest();
+        self.validation = ValidationContext::new(self.timestamp_ms, self.timestamp_ms, work_forest);
+        self.txs.clear();
+    }
+
+    /// Adds transaction to the mempool and verifies it.
+    pub fn append<P: Borrow<utreexo::Proof>>(
+        &mut self,
+        tx: Tx,
+        utxo_proofs: impl IntoIterator<Item = P>,
+        bp_gens: &BulletproofGens,
+    ) -> Result<TxID, BlockchainError> {
+        let verified_tx = self
+            .validation
+            .apply_tx(&tx, utxo_proofs.into_iter(), bp_gens)?;
+        let txid = verified_tx.id;
+        self.txs.push((tx, verified_tx));
+        Ok(txid)
+    }
+}

--- a/zkvm/src/blockchain/mempool.rs
+++ b/zkvm/src/blockchain/mempool.rs
@@ -44,16 +44,14 @@ impl Mempool {
         self.txs.iter().map(|(tx, _, _)| tx)
     }
 
+    /// Returns a list of transactions
+    pub fn utxo_proofs(&self) -> impl Iterator<Item = &utreexo::Proof> {
+        self.txs.iter().flat_map(|(_, _, proofs)| proofs.iter())
+    }
+
     /// Returns the size of the mempool in number of transactions.
     pub fn len(&self) -> usize {
         self.txs.len()
-    }
-
-    /// Clears mempool.
-    pub fn reset(&mut self) {
-        let work_forest = self.state.utreexo.work_forest();
-        self.validation = ValidationContext::new(self.timestamp_ms, self.timestamp_ms, work_forest);
-        self.txs.clear();
     }
 
     /// Updates timestamp and re-applies txs to filter out the outdated ones.

--- a/zkvm/src/blockchain/mod.rs
+++ b/zkvm/src/blockchain/mod.rs
@@ -2,6 +2,7 @@
 
 mod block;
 mod errors;
+mod mempool;
 mod state;
 
 #[cfg(test)]
@@ -9,4 +10,5 @@ mod tests;
 
 pub use self::block::*;
 pub use self::errors::*;
+pub use self::mempool::*;
 pub use self::state::*;

--- a/zkvm/src/blockchain/state.rs
+++ b/zkvm/src/blockchain/state.rs
@@ -20,13 +20,22 @@ pub struct BlockchainState {
     pub catchup: Catchup,
 }
 
+/// All the data necessary for validating and applying transactions.
+/// `BlockchainState` API uses it to apply a block of transactions.
+/// `Mempool` API uses it to apply one transaction after another.
+pub(super) struct ValidationContext {
+    block_version: u64,
+    timestamp_ms: u64,
+    work_forest: WorkForest,
+    hasher: NodeHasher<ContractID>,
+}
+
 impl BlockchainState {
     /// Creates an initial block with a given starting set of utxos.
     pub fn make_initial<I>(timestamp_ms: u64, utxos: I) -> (BlockchainState, Vec<utreexo::Proof>)
     where
         I: IntoIterator<Item = ContractID> + Clone,
     {
-        // Q: why do we need to re-use an ?
         let hasher = NodeHasher::new();
         let (_, utreexo, catchup) = Forest::new()
             .update(&hasher, |forest| {
@@ -53,52 +62,6 @@ impl BlockchainState {
         (state, proofs)
     }
 
-    /// Applies the block to the current state and returns a new one.
-    pub fn apply_block(
-        &mut self,
-        block: &Block,
-        bp_gens: &BulletproofGens,
-    ) -> Result<(VerifiedBlock, BlockchainState), BlockchainError> {
-        check_block_header(&block.header, &self.tip)?;
-
-        let hasher = NodeHasher::new();
-        let mut work_forest = self.utreexo.work_forest();
-
-        let (txroot, verified_txs) = apply_txs(
-            block.header.version,
-            block.header.timestamp_ms,
-            block.txs.iter(),
-            block.utxo_proofs(),
-            &mut work_forest,
-            &hasher,
-            bp_gens,
-        )?;
-
-        if block.header.txroot != txroot {
-            return Err(BlockchainError::InconsistentHeader);
-        }
-
-        let (new_forest, new_catchup) = work_forest.normalize(&hasher);
-
-        if block.header.utxoroot != new_forest.root(&hasher) {
-            return Err(BlockchainError::InconsistentHeader);
-        }
-
-        let verified_block = VerifiedBlock {
-            header: block.header.clone(),
-            txs: verified_txs,
-        };
-
-        let new_state = BlockchainState {
-            initial_id: self.initial_id,
-            tip: block.header.clone(),
-            utreexo: new_forest,
-            catchup: new_catchup,
-        };
-
-        Ok((verified_block, new_state))
-    }
-
     /// Creates a new block with a set of verified transactions.
     /// Also returns a new blockchain state.
     pub fn make_block(
@@ -119,22 +82,10 @@ impl BlockchainState {
             BlockchainError::InconsistentHeader,
         )?;
 
-        let hasher = NodeHasher::new();
-        let mut work_forest = self.utreexo.work_forest();
-
-        let (txroot, verified_txs) = apply_txs(
-            block_version,
-            timestamp_ms,
-            txs.iter(),
-            utxo_proofs.iter(),
-            &mut work_forest,
-            &hasher,
-            bp_gens,
-        )?;
-
-        let (new_forest, new_catchup) = work_forest.normalize(&hasher);
-
-        let utxoroot = new_forest.root(&hasher);
+        let mut ctx =
+            ValidationContext::new(block_version, timestamp_ms, self.utreexo.work_forest());
+        let (txroot, verified_txs) = ctx.apply_txs(txs.iter(), utxo_proofs.iter(), bp_gens)?;
+        let (utxoroot, new_forest, new_catchup) = ctx.normalize_state();
 
         let header = BlockHeader {
             version: block_version,
@@ -166,83 +117,147 @@ impl BlockchainState {
 
         Ok((new_block, new_block_verified, new_state))
     }
+
+    /// Applies the block to the current state and returns a new one.
+    pub fn apply_block(
+        &mut self,
+        block: &Block,
+        bp_gens: &BulletproofGens,
+    ) -> Result<(VerifiedBlock, BlockchainState), BlockchainError> {
+        check_block_header(&self.tip, &block.header)?;
+
+        let mut ctx = ValidationContext::new(
+            block.header.version,
+            block.header.timestamp_ms,
+            self.utreexo.work_forest(),
+        );
+
+        let (txroot, verified_txs) =
+            ctx.apply_txs(block.txs.iter(), block.utxo_proofs(), bp_gens)?;
+
+        if block.header.txroot != txroot {
+            return Err(BlockchainError::InconsistentHeader);
+        }
+
+        let (utxoroot, new_forest, new_catchup) = ctx.normalize_state();
+
+        if block.header.utxoroot != utxoroot {
+            return Err(BlockchainError::InconsistentHeader);
+        }
+
+        let verified_block = VerifiedBlock {
+            header: block.header.clone(),
+            txs: verified_txs,
+        };
+
+        let new_state = BlockchainState {
+            initial_id: self.initial_id,
+            tip: block.header.clone(),
+            utreexo: new_forest,
+            catchup: new_catchup,
+        };
+
+        Ok((verified_block, new_state))
+    }
 }
 
-/// Applies a single transaction to the state.
-fn apply_tx<P: Borrow<utreexo::Proof>>(
-    block_version: u64,
-    timestamp_ms: u64,
-    tx: &Tx,
-    utxo_proofs: impl IntoIterator<Item = P>,
-    work_forest: &mut WorkForest,
-    hasher: &NodeHasher<ContractID>,
-    bp_gens: &BulletproofGens,
-) -> Result<VerifiedTx, BlockchainError> {
-    let mut utxo_proofs = utxo_proofs.into_iter();
-
-    check_tx_header(&tx.header, block_version, timestamp_ms)?;
-
-    let verified_tx =
-        Verifier::verify_tx(tx, bp_gens).map_err(|e| BlockchainError::TxValidation(e))?;
-
-    for entry in verified_tx.log.iter() {
-        match entry {
-            // Remove item from the UTXO set
-            TxEntry::Input(contract_id) => {
-                let proof = utxo_proofs
-                    .next()
-                    .ok_or(BlockchainError::UtreexoProofMissing)?;
-                work_forest
-                    .delete(contract_id, proof.borrow(), &hasher)
-                    .map_err(|e| BlockchainError::UtreexoError(e))?;
-            }
-            // Add item to the UTXO set
-            TxEntry::Output(contract) => {
-                work_forest.insert(&contract.id(), &hasher);
-            }
-            _ => {}
+impl ValidationContext {
+    /// Create a new context with given block version, timestamp and work forest for utxos.
+    pub fn new(block_version: u64, timestamp_ms: u64, work_forest: WorkForest) -> Self {
+        Self {
+            block_version,
+            timestamp_ms,
+            work_forest,
+            hasher: NodeHasher::new(),
         }
     }
 
-    Ok(verified_tx)
-}
+    /// Applies a list of transactions to the state and returns the txroot.
+    pub fn apply_txs<T: Borrow<Tx>, P: Borrow<utreexo::Proof>>(
+        &mut self,
+        txs: impl IntoIterator<Item = T>,
+        utxo_proofs: impl IntoIterator<Item = P>,
+        bp_gens: &BulletproofGens,
+    ) -> Result<(Hash, Vec<VerifiedTx>), BlockchainError> {
+        let mut utxo_proofs = utxo_proofs.into_iter();
+        let verified_txs = txs
+            .into_iter()
+            .map(|tx| self.apply_tx(tx.borrow(), &mut utxo_proofs, bp_gens))
+            .collect::<Result<Vec<_>, _>>()?;
 
-/// Applies a list of transactions to the state and returns the txroot.
-fn apply_txs<T: Borrow<Tx>, P: Borrow<utreexo::Proof>>(
-    block_version: u64,
-    timestamp_ms: u64,
-    txs: impl IntoIterator<Item = T>,
-    utxo_proofs: impl IntoIterator<Item = P>,
-    mut work_forest: &mut WorkForest,
-    hasher: &NodeHasher<ContractID>,
-    bp_gens: &BulletproofGens,
-) -> Result<(Hash, Vec<VerifiedTx>), BlockchainError> {
-    let mut utxo_proofs = utxo_proofs.into_iter();
-    let verified_txs = txs
-        .into_iter()
-        .map(|tx| {
-            apply_tx(
-                block_version,
-                timestamp_ms,
-                tx.borrow(),
-                &mut utxo_proofs,
-                &mut work_forest,
-                &hasher,
-                bp_gens,
-            )
-        })
-        .collect::<Result<Vec<_>, _>>()?;
+        // TBD: change this O(n) allocation to a more compact (log(n)) merkle root hasher.
+        let txids = verified_txs.iter().map(|tx| tx.id).collect::<Vec<_>>();
+        let txroot = MerkleTree::root(b"ZkVM.txroot", &txids);
+        Ok((txroot, verified_txs))
+    }
 
-    // TBD: change this O(n) allocation to a more compact (log(n)) merkle root hasher.
-    let txids = verified_txs.iter().map(|tx| tx.id).collect::<Vec<_>>();
-    let txroot = MerkleTree::root(b"ZkVM.txroot", &txids);
-    Ok((txroot, verified_txs))
+    /// Applies a single transaction to the state.
+    /// FIXME: this is not atomic!!!
+    pub fn apply_tx<P: Borrow<utreexo::Proof>>(
+        &mut self,
+        tx: &Tx,
+        utxo_proofs: impl IntoIterator<Item = P>,
+        bp_gens: &BulletproofGens,
+    ) -> Result<VerifiedTx, BlockchainError> {
+        let mut utxo_proofs = utxo_proofs.into_iter();
+
+        self.check_tx_header(&tx.header)?;
+
+        let verified_tx =
+            Verifier::verify_tx(tx, bp_gens).map_err(|e| BlockchainError::TxValidation(e))?;
+
+        for entry in verified_tx.log.iter() {
+            match entry {
+                // Remove item from the UTXO set
+                TxEntry::Input(contract_id) => {
+                    let proof = utxo_proofs
+                        .next()
+                        .ok_or(BlockchainError::UtreexoProofMissing)?;
+
+                    self.work_forest
+                        .delete(contract_id, proof.borrow(), &self.hasher)
+                        .map_err(|e| BlockchainError::UtreexoError(e))?;
+                }
+                // Add item to the UTXO set
+                TxEntry::Output(contract) => {
+                    self.work_forest.insert(&contract.id(), &self.hasher);
+                }
+                // Ignore all other log items
+                _ => {}
+            }
+        }
+
+        Ok(verified_tx)
+    }
+
+    /// Normalizes the state into a new compact forest.
+    pub fn normalize_state(self) -> (Hash, Forest, Catchup) {
+        let (forest, catchup) = self.work_forest.normalize(&self.hasher);
+        let root = forest.root(&self.hasher);
+        (root, forest, catchup)
+    }
+
+    /// Checks the tx header for consistency with the block header.
+    fn check_tx_header(&self, tx_header: &TxHeader) -> Result<(), BlockchainError> {
+        check(
+            tx_header.mintime_ms <= self.timestamp_ms,
+            BlockchainError::BadTxTimestamp,
+        )?;
+        check(
+            tx_header.maxtime_ms >= self.timestamp_ms,
+            BlockchainError::BadTxTimestamp,
+        )?;
+        if self.block_version == 1 {
+            check(tx_header.version == 1, BlockchainError::BadTxVersion)?;
+        }
+        Ok(())
+    }
 }
 
 /// Verifies consistency of the block header with respect to the previous block header.
 fn check_block_header(
-    block_header: &BlockHeader,
     prev_header: &BlockHeader,
+    block_header: &BlockHeader,
 ) -> Result<(), BlockchainError> {
     check(
         block_header.version >= prev_header.version,
@@ -269,26 +284,27 @@ fn check_block_header(
     Ok(())
 }
 
-/// Checks the tx header for consistency with the block header.
-fn check_tx_header(
-    tx_header: &TxHeader,
-    block_version: u64,
-    timestamp_ms: u64,
-) -> Result<(), BlockchainError> {
-    check(
-        tx_header.mintime_ms <= timestamp_ms,
-        BlockchainError::BadTxTimestamp,
-    )?;
-    check(
-        tx_header.maxtime_ms >= timestamp_ms,
-        BlockchainError::BadTxTimestamp,
-    )?;
-    if block_version == 1 {
-        check(tx_header.version == 1, BlockchainError::BadTxVersion)?;
-    }
-    Ok(())
-}
+// /// Checks the tx header for consistency with the block header.
+// fn check_tx_header(
+//     tx_header: &TxHeader,
+//     block_version: u64,
+//     timestamp_ms: u64,
+// ) -> Result<(), BlockchainError> {
+//     check(
+//         tx_header.mintime_ms <= timestamp_ms,
+//         BlockchainError::BadTxTimestamp,
+//     )?;
+//     check(
+//         tx_header.maxtime_ms >= timestamp_ms,
+//         BlockchainError::BadTxTimestamp,
+//     )?;
+//     if block_version == 1 {
+//         check(tx_header.version == 1, BlockchainError::BadTxVersion)?;
+//     }
+//     Ok(())
+// }
 
+#[inline]
 fn check(cond: bool, err: BlockchainError) -> Result<(), BlockchainError> {
     if !cond {
         return Err(err);

--- a/zkvm/src/blockchain/state.rs
+++ b/zkvm/src/blockchain/state.rs
@@ -181,7 +181,7 @@ impl ValidationContext {
 
     /// Applies a list of transactions to the state and returns the txroot.
     /// FIXME: make this more sanely organized.
-    pub fn apply_txs_nonatomic<T: Borrow<Tx>, P: Borrow<utreexo::Proof>>(
+    fn apply_txs_nonatomic<T: Borrow<Tx>, P: Borrow<utreexo::Proof>>(
         &mut self,
         txs: impl IntoIterator<Item = T>,
         utxo_proofs: impl IntoIterator<Item = P>,


### PR DESCRIPTION
- [x] support utxo proofs for transient items (that were added during the same block)
- [x] utreexo: transactional API to undo changes from invalid txs
- [x] integrate transactional API with mempool
- [x] integrate mempool into the demo app

BIG CAVEAT: if app is rebooted, mempool is cleared. But if it was not empty, users' persistent state is left in inconsistent state. We'll fix it with persistent mempool, and then improve with expiring txs.