### PR TITLE
zkvm: clean up merkle tree codebase, remove redundancy

### DIFF
--- a/accounts/src/tests.rs
+++ b/accounts/src/tests.rs
@@ -290,7 +290,7 @@ fn process_block(
         .expect("We expect a valid block");
 
     // In a real node utxos will be indexed by ContractID, so lookup will be more efficient.
-    let hasher = utreexo::NodeHasher::new();
+    let hasher = utreexo::utreexo_hasher();
     for entry in vtxs.iter().flat_map(|vtx| vtx.log.iter()) {
         match entry {
             TxEntry::Input(contract_id) => {

--- a/zkvm/src/blockchain/tests.rs
+++ b/zkvm/src/blockchain/tests.rs
@@ -102,7 +102,7 @@ fn test_state_machine() {
         .apply_block(future_state.tip, &[vtx], proofs.iter())
         .expect("Block application should succeed.");
 
-    let hasher = utreexo::NodeHasher::<ContractID>::new();
+    let hasher = utreexo::utreexo_hasher::<ContractID>();
     assert_eq!(
         new_state.utreexo.root(&hasher),
         future_state.utreexo.root(&hasher)

--- a/zkvm/src/lib.rs
+++ b/zkvm/src/lib.rs
@@ -30,7 +30,7 @@ pub use self::constraints::{Commitment, CommitmentWitness, Constraint, Expressio
 pub use self::contract::{Anchor, Contract, ContractID, PortableItem};
 pub use self::encoding::Encodable;
 pub use self::errors::VMError;
-pub use self::merkle::{Hash, MerkleItem, MerkleNeighbor, MerkleTree};
+pub use self::merkle::{Hash, MerkleItem, MerkleTree};
 pub use self::ops::{Instruction, Opcode};
 pub use self::predicate::{Predicate, PredicateTree};
 pub use self::program::{Program, ProgramItem};

--- a/zkvm/src/merkle.rs
+++ b/zkvm/src/merkle.rs
@@ -44,7 +44,6 @@ pub enum MerkleNeighbor {
 /// Merkle tree of hashes with a given size.
 pub struct MerkleTree {
     size: usize,
-    label: &'static [u8],
     root: MerkleNode,
 }
 
@@ -83,7 +82,6 @@ impl MerkleTree {
         let root = Self::build_tree(&Hasher::new(label), list);
         MerkleTree {
             size: list.len(),
-            label,
             root,
         }
     }
@@ -99,9 +97,8 @@ impl MerkleTree {
         if index >= self.size {
             return Err(VMError::InvalidMerkleProof);
         }
-        let t = Transcript::new(self.label);
         let mut result = Vec::new();
-        self.root.subpath(t, index, self.size, &mut result)?;
+        self.root.subpath(index, self.size, &mut result)?;
         Ok(result)
     }
 
@@ -223,7 +220,6 @@ impl MerkleItem for () {
 impl MerkleNode {
     fn subpath(
         &self,
-        t: Transcript,
         index: usize,
         size: usize,
         result: &mut Vec<MerkleNeighbor>,
@@ -235,10 +231,10 @@ impl MerkleNode {
                 let k = size.next_power_of_two() / 2;
                 if index >= k {
                     result.insert(0, MerkleNeighbor::Left(l.hash().clone()));
-                    r.subpath(t, index - k, size - k, result)
+                    r.subpath(index - k, size - k, result)
                 } else {
                     result.insert(0, MerkleNeighbor::Right(r.hash().clone()));
-                    return l.subpath(t, index, k, result);
+                    return l.subpath(index, k, result);
                 }
             }
         }

--- a/zkvm/src/merkle.rs
+++ b/zkvm/src/merkle.rs
@@ -3,6 +3,8 @@ use core::marker::PhantomData;
 use merlin::Transcript;
 use std::fmt;
 use subtle::ConstantTimeEq;
+use serde::{Deserialize, Serialize};
+use crate::encoding::{self,Encodable};
 
 use crate::errors::VMError;
 
@@ -287,7 +289,8 @@ impl<M: MerkleItem> Hasher<M> {
         }
     }
 
-    pub(super) fn leaf(&self, item: &M) -> Hash {
+    /// Computes hash of the leaf node in a merkle tree.
+    pub fn leaf(&self, item: &M) -> Hash {
         let mut t = self.t.clone();
         item.commit(&mut t);
         let mut hash = Hash::default();
@@ -295,7 +298,8 @@ impl<M: MerkleItem> Hasher<M> {
         hash
     }
 
-    pub(super) fn intermediate(&self, left: &Hash, right: &Hash) -> Hash {
+    /// Computes hash of the inner node in a merkle tree (that contains left/right child nodes).
+    pub fn intermediate(&self, left: &Hash, right: &Hash) -> Hash {
         let mut t = self.t.clone();
         t.append_message(b"L", &left);
         t.append_message(b"R", &right);
@@ -304,11 +308,139 @@ impl<M: MerkleItem> Hasher<M> {
         hash
     }
 
-    pub(super) fn empty(&self) -> Hash {
+    /// Computes a hash of an empty tree.
+    pub fn empty(&self) -> Hash {
         let mut t = self.t.clone();
         let mut hash = Hash::default();
         t.challenge_bytes(b"merkle.empty", &mut hash);
         hash
+    }
+}
+
+
+/// Absolute position of an item in the tree.
+pub type Position = u64;
+
+/// Merkle proof of inclusion of a node in a `Forest`.
+/// The exact tree is determined by the `position`, an absolute position of the item
+/// within the set of all items in the forest.
+/// Neighbors are counted from lowest to the highest.
+/// Left/right position of the neighbor is determined by the appropriate bit in `position`.
+/// (Lowest bit=1 means the first neighbor is to the left of the node.)
+/// `path` is None if this proof is for a newly added item that has no merkle path yet.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct Path {
+    /// Position of the item under this path.
+    pub position: Position,
+    /// List of neighbor hashes for this path.
+    pub neighbors: Vec<Hash>,
+}
+
+#[derive(Copy, Clone, PartialEq, Debug)]
+pub enum Side {
+    /// Indicates that the item is to the left of its neighbor.
+    Left,
+    /// Indicates that the item is to the right of its neighbor.
+    Right,
+}
+
+
+impl Side {
+    /// Orders (current, neighbor) pair of nodes as (left, right)
+    /// Alternative meaning in context of a path traversal: orders (left, right) pair of nodes as (main, neighbor)
+    pub fn order<T>(self, a: T, b: T) -> (T, T) {
+        match self {
+            Side::Left => (a, b),
+            Side::Right => (b, a),
+        }
+    }
+
+    fn from_bit(bit: u8) -> Self {
+        match bit {
+            0 => Side::Left,
+            _ => Side::Right,
+        }
+    }
+}
+
+impl Default for Path {
+    fn default() -> Path {
+        Path {
+            position: 0,
+            neighbors: Vec::new(),
+        }
+    }
+}
+
+impl Path {
+    pub(super) fn iter(
+        &self,
+    ) -> impl DoubleEndedIterator<Item = (Side, &Hash)> + ExactSizeIterator {
+        self.directions().zip(self.neighbors.iter())
+    }
+    fn directions(&self) -> Directions {
+        Directions {
+            position: self.position,
+            depth: self.neighbors.len(),
+        }
+    }
+}
+
+impl Encodable for Path {
+    fn encode(&self, buf: &mut Vec<u8>) {
+        encoding::write_u64(self.position, buf);
+        encoding::write_size(self.neighbors.len(), buf);
+        for hash in self.neighbors.iter() {
+            encoding::write_bytes(&hash[..], buf);
+        }
+    }
+
+    fn serialized_length(&self) -> usize {
+        return 8 + 4 + 32 * self.neighbors.len();
+    }
+}
+
+/// Simialr to Path, but does not contain neighbors - only left/right directions
+/// as indicated by the bits in the `position`.
+#[derive(Copy, Clone, PartialEq, Debug)]
+pub struct Directions {
+    pub position: Position,
+    pub depth: usize,
+}
+
+impl ExactSizeIterator for Directions {
+    fn len(&self) -> usize {
+        self.depth
+    }
+}
+
+impl Iterator for Directions {
+    type Item = Side;
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.depth == 0 {
+            return None;
+        }
+        let side = Side::from_bit((self.position & 1) as u8);
+        // kick out the lowest bit and shrink the depth
+        self.position >>= 1;
+        self.depth -= 1;
+        Some(side)
+    }
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (self.len(), Some(self.len()))
+    }
+}
+
+impl DoubleEndedIterator for Directions {
+    fn next_back(&mut self) -> Option<Self::Item> {
+        if self.depth == 0 {
+            return None;
+        }
+        self.depth -= 1;
+        // Note: we do not mask out the bit in `position` because we don't expose it.
+        // The bit is ignored implicitly by having the depth decremented.
+        let side = Side::from_bit(((self.position >> self.depth) & 1) as u8);
+        Some(side)
     }
 }
 

--- a/zkvm/src/predicate.rs
+++ b/zkvm/src/predicate.rs
@@ -235,8 +235,10 @@ impl PredicateTree {
             PredicateLeaf::Blinding(_) => 2 * prog_index + 1,
             PredicateLeaf::Program(_) => 2 * prog_index,
         };
-        let tree = MerkleTree::build(b"ZkVM.taproot", &self.leaves);
-        let path = tree.create_path(leaf_index).ok_or(VMError::BadArguments)?;
+        // let tree = MerkleTree::build(b"ZkVM.taproot", &self.leaves);
+        // let path = tree.create_path(leaf_index).ok_or(VMError::BadArguments)?;
+        let path = Path::new(&self.leaves, leaf_index, &Hasher::new(b"ZkVM.taproot"))
+            .ok_or(VMError::BadArguments)?;
         let verification_key = self.key.clone();
         let call_proof = CallProof {
             verification_key,

--- a/zkvm/src/predicate.rs
+++ b/zkvm/src/predicate.rs
@@ -15,7 +15,7 @@ use crate::encoding;
 use crate::encoding::Encodable;
 use crate::encoding::SliceReader;
 use crate::errors::VMError;
-use crate::merkle::{Hash, MerkleItem, MerkleNeighbor, MerkleTree};
+use crate::merkle::{Hash, Hasher, MerkleItem, MerkleTree, Path};
 use crate::program::{Program, ProgramItem};
 use crate::transcript::TranscriptProtocol;
 
@@ -61,8 +61,8 @@ pub struct CallProof {
     // Pure verification key
     pub verification_key: VerificationKey,
 
-    // List of left-right neighbors, excluding the root and leaf hash
-    pub neighbors: Vec<MerkleNeighbor>,
+    // Merkle path.
+    pub path: Path,
 }
 
 /// PredicateLeaf represents a leaf in the merkle tree of predicate's clauses.
@@ -144,8 +144,9 @@ impl Predicate {
         batch: &mut impl BatchVerification,
     ) {
         let key = &call_proof.verification_key;
-        let neighbors = &call_proof.neighbors;
-        let root = MerkleTree::compute_root_from_path(b"ZkVM.taproot", program_item, neighbors);
+        let root = &call_proof
+            .path
+            .compute_root(program_item, &Hasher::new(b"ZkVM.taproot"));
         let h = Self::commit_taproot(key, &root);
 
         // P == X + h1(X, M)*B -> 0 == -P + X + h1(X, M)*B
@@ -235,11 +236,11 @@ impl PredicateTree {
             PredicateLeaf::Program(_) => 2 * prog_index,
         };
         let tree = MerkleTree::build(b"ZkVM.taproot", &self.leaves);
-        let neighbors = tree.create_path(leaf_index)?;
+        let path = tree.create_path(leaf_index).ok_or(VMError::BadArguments)?;
         let verification_key = self.key.clone();
         let call_proof = CallProof {
             verification_key,
-            neighbors,
+            path,
         };
         let program = self.leaves[leaf_index].clone().to_program()?;
         Ok((call_proof, program))
@@ -281,55 +282,20 @@ impl Encodable for CallProof {
     /// Serializes the call proof to a byte array.
     fn encode(&self, buf: &mut Vec<u8>) {
         encoding::write_point(self.verification_key.as_point(), buf);
-
-        let num_neighbors = self.neighbors.len();
-        let mut positions: u32 = 1 << num_neighbors;
-        for (i, n) in self.neighbors.iter().enumerate() {
-            match n {
-                MerkleNeighbor::Right(_) => {
-                    positions = positions | (1 << i);
-                }
-                _ => {}
-            }
-        }
-        encoding::write_u32(positions, buf);
-        for n in &self.neighbors {
-            match n {
-                MerkleNeighbor::Left(l) => encoding::write_bytes(l, buf),
-                MerkleNeighbor::Right(r) => encoding::write_bytes(r, buf),
-            }
-        }
+        self.path.encode(buf);
     }
     fn serialized_length(&self) -> usize {
-        // VerificationKey is a 32-byte array
-        // MerkleNeighbor is a 32-byte array
-        32 + 4 + self.neighbors.len() * 32
+        32 + self.path.serialized_length()
     }
 }
 
 impl CallProof {
     /// Decodes the call proof from bytes.
     pub fn decode<'a>(reader: &mut SliceReader<'a>) -> Result<Self, VMError> {
-        let verification_key =
-            VerificationKey::from_compressed(reader.read_point()?).ok_or(VMError::InvalidPoint)?;
-
-        let positions = reader.read_u32()?;
-        if positions == 0 {
-            return Err(VMError::FormatError);
-        }
-        let num_neighbors = (31 - positions.leading_zeros()) as usize;
-        let mut neighbors = Vec::with_capacity(num_neighbors);
-        for i in 0..num_neighbors {
-            let bytes = Hash(reader.read_u8x32()?);
-            neighbors.push(if positions & (1 << i) == 0 {
-                MerkleNeighbor::Left(bytes)
-            } else {
-                MerkleNeighbor::Right(bytes)
-            });
-        }
+        let point = VerificationKey::from_compressed(reader.read_point()?);
         Ok(CallProof {
-            verification_key,
-            neighbors,
+            verification_key: point.ok_or(VMError::InvalidPoint)?,
+            path: Path::decode(reader)?,
         })
     }
 

--- a/zkvm/src/tx.rs
+++ b/zkvm/src/tx.rs
@@ -289,7 +289,7 @@ impl MerkleItem for TxEntry {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::merkle::Hasher;
+    use crate::merkle::{Hasher, Path};
 
     fn txlog_helper() -> Vec<TxEntry> {
         vec![
@@ -310,25 +310,25 @@ mod tests {
 
     #[test]
     fn valid_txid_proof() {
+        let hasher = Hasher::new(b"ZkVM.txid");
         let (entry, txid, path) = {
             let entries = txlog_helper();
-            let root = MerkleTree::build(b"ZkVM.txid", &entries);
             let index = 3;
-            let path = root.create_path(index).unwrap();
+            let path = Path::new(&entries, index, &hasher).unwrap();
             (entries[index].clone(), TxID::from_log(&entries), path)
         };
-        assert!(path.verify_root(&txid.0, &entry, &Hasher::new(b"ZkVM.txid")));
+        assert!(path.verify_root(&txid.0, &entry, &hasher));
     }
 
     #[test]
     fn invalid_txid_proof() {
+        let hasher = Hasher::new(b"ZkVM.txid");
         let (entry, txid, path) = {
             let entries = txlog_helper();
-            let root = MerkleTree::build(b"ZkVM.txid", &entries);
             let index = 3;
-            let path = root.create_path(index).unwrap();
+            let path = Path::new(&entries, index, &hasher).unwrap();
             (entries[index + 1].clone(), TxID::from_log(&entries), path)
         };
-        assert!(path.verify_root(&txid.0, &entry, &Hasher::new(b"ZkVM.txid")) == false);
+        assert!(path.verify_root(&txid.0, &entry, &hasher) == false);
     }
 }

--- a/zkvm/src/utreexo/forest.rs
+++ b/zkvm/src/utreexo/forest.rs
@@ -4,8 +4,8 @@ use std::collections::HashMap;
 use std::fmt;
 use std::mem;
 
-use super::path::{Directions, Path, Position, Proof};
-use crate::merkle::{Hash, Hasher, MerkleItem};
+use super::path::{Proof};
+use crate::merkle::{Hash, Hasher, MerkleItem, Directions, Path, Position};
 
 /// Forest consists of a number of roots of merkle binary trees.
 #[derive(Clone, Serialize, Deserialize)]

--- a/zkvm/src/utreexo/forest.rs
+++ b/zkvm/src/utreexo/forest.rs
@@ -4,8 +4,8 @@ use std::collections::HashMap;
 use std::fmt;
 use std::mem;
 
-use super::path::{Proof};
-use crate::merkle::{Hash, Hasher, MerkleItem, Directions, Path, Position};
+use super::path::Proof;
+use crate::merkle::{Directions, Hash, Hasher, MerkleItem, Path, Position};
 
 /// Forest consists of a number of roots of merkle binary trees.
 #[derive(Clone, Serialize, Deserialize)]

--- a/zkvm/src/utreexo/forest.rs
+++ b/zkvm/src/utreexo/forest.rs
@@ -4,8 +4,8 @@ use std::collections::HashMap;
 use std::fmt;
 use std::mem;
 
+use super::heap::{Heap, HeapIndex};
 use super::path::Proof;
-use super::heap::{Heap,HeapIndex};
 use crate::merkle::{Directions, Hash, Hasher, MerkleItem, Path, Position};
 
 /// Forest consists of a number of roots of merkle binary trees.

--- a/zkvm/src/utreexo/forest.rs
+++ b/zkvm/src/utreexo/forest.rs
@@ -5,6 +5,7 @@ use std::fmt;
 use std::mem;
 
 use super::path::Proof;
+use super::heap::{Heap,HeapIndex};
 use crate::merkle::{Directions, Hash, Hasher, MerkleItem, Path, Position};
 
 /// Forest consists of a number of roots of merkle binary trees.
@@ -638,91 +639,6 @@ fn find_root(roots: impl IntoIterator<Item = usize>, position: Position) -> Opti
         }
     }
     None
-}
-
-/// Clone-on-write heap implementation with the following key features:
-/// 1. No lifetimes - does not poison the APIs using it.
-/// 2. Compatible with cross-thread access (if you access this via Mutex/RwLock)
-///    because there are no smart pointers.
-#[derive(Clone, PartialEq, Debug, Serialize, Deserialize)]
-struct Heap<T: Clone> {
-    checkpoint: usize, // all items before this index are considered immutable and cloned by `make_mut`.
-    items: Vec<T>,
-}
-
-#[derive(Copy, Clone, PartialEq, Debug, Serialize, Deserialize)]
-struct HeapIndex(usize);
-
-struct HeapCheckpoint {
-    prev: usize,
-    curr: usize,
-}
-
-impl<T: Clone> Heap<T> {
-    /// Creates a new empty heap.
-    pub(super) fn new() -> Self {
-        Self {
-            checkpoint: 0,
-            items: Vec::new(),
-        }
-    }
-
-    /// Creates a checkpoint: remembers which items must remain unchanged until a rollback.
-    pub(super) fn checkpoint(&mut self) -> HeapCheckpoint {
-        let cp = HeapCheckpoint {
-            prev: self.checkpoint,
-            curr: self.items.len(),
-        };
-        self.checkpoint = cp.curr;
-        cp
-    }
-
-    /// Rolls back to the previous state.
-    /// Panics if the wrong checkpoint is used.
-    pub(super) fn rollback(&mut self, checkpoint: HeapCheckpoint) {
-        assert!(self.checkpoint == checkpoint.curr);
-        self.items.truncate(checkpoint.curr);
-        self.checkpoint = checkpoint.prev;
-    }
-
-    /// Commits existing changes and shifts checkpoint to the previous position.
-    pub(super) fn commit(&mut self, checkpoint: HeapCheckpoint) {
-        assert!(self.checkpoint == checkpoint.curr);
-        self.checkpoint = checkpoint.prev;
-    }
-
-    /// Adds an item to the heap.
-    pub(super) fn allocate(&mut self, item: T) -> HeapIndex {
-        self.items.push(item);
-        HeapIndex(self.items.len() - 1)
-    }
-
-    /// Returns an immutable borrow of the item at index.
-    pub(super) fn get_ref(&self, index: HeapIndex) -> &T {
-        &self.items[index.0]
-    }
-
-    /// Returns a mutable borrow of the item at index, or None if that
-    /// item was created before the checkpoint
-    pub(super) fn get_mut(&mut self, index: HeapIndex) -> Option<&mut T> {
-        if index.0 >= self.checkpoint {
-            Some(&mut self.items[index.0])
-        } else {
-            None
-        }
-    }
-
-    /// Returns a mutable borrow of the item at index.
-    /// If the item exists in the backing heap, it is automatically cloned and inserted in this heap.
-    /// The index is automatically updated to the new item in this case.
-    pub(super) fn make_mut(&mut self, index: &mut HeapIndex) -> &mut T {
-        if index.0 < self.checkpoint {
-            let item = self.items[index.0].clone();
-            self.items.push(item);
-            *index = HeapIndex(self.items.len() - 1);
-        }
-        &mut self.items[index.0]
-    }
 }
 
 impl fmt::Debug for Forest {

--- a/zkvm/src/utreexo/heap.rs
+++ b/zkvm/src/utreexo/heap.rs
@@ -1,0 +1,86 @@
+use serde::{Deserialize, Serialize};
+
+/// Clone-on-write heap implementation with the following key features:
+/// 1. No lifetimes - does not poison the APIs using it.
+/// 2. Compatible with cross-thread access (if you access this via Mutex/RwLock)
+///    because there are no smart pointers.
+#[derive(Clone, PartialEq, Debug, Serialize, Deserialize)]
+pub struct Heap<T: Clone> {
+    checkpoint: usize, // all items before this index are considered immutable and cloned by `make_mut`.
+    items: Vec<T>,
+}
+
+#[derive(Copy, Clone, PartialEq, Debug, Serialize, Deserialize)]
+pub struct HeapIndex(usize);
+
+pub struct HeapCheckpoint {
+    prev: usize,
+    curr: usize,
+}
+
+impl<T: Clone> Heap<T> {
+    /// Creates a new empty heap.
+    pub fn new() -> Self {
+        Self {
+            checkpoint: 0,
+            items: Vec::new(),
+        }
+    }
+
+    /// Creates a checkpoint: remembers which items must remain unchanged until a rollback.
+    pub fn checkpoint(&mut self) -> HeapCheckpoint {
+        let cp = HeapCheckpoint {
+            prev: self.checkpoint,
+            curr: self.items.len(),
+        };
+        self.checkpoint = cp.curr;
+        cp
+    }
+
+    /// Rolls back to the previous state.
+    /// Panics if the wrong checkpoint is used.
+    pub fn rollback(&mut self, checkpoint: HeapCheckpoint) {
+        assert!(self.checkpoint == checkpoint.curr);
+        self.items.truncate(checkpoint.curr);
+        self.checkpoint = checkpoint.prev;
+    }
+
+    /// Commits existing changes and shifts checkpoint to the previous position.
+    pub fn commit(&mut self, checkpoint: HeapCheckpoint) {
+        assert!(self.checkpoint == checkpoint.curr);
+        self.checkpoint = checkpoint.prev;
+    }
+
+    /// Adds an item to the heap.
+    pub fn allocate(&mut self, item: T) -> HeapIndex {
+        self.items.push(item);
+        HeapIndex(self.items.len() - 1)
+    }
+
+    /// Returns an immutable borrow of the item at index.
+    pub fn get_ref(&self, index: HeapIndex) -> &T {
+        &self.items[index.0]
+    }
+
+    /// Returns a mutable borrow of the item at index, or None if that
+    /// item was created before the checkpoint
+    pub fn get_mut(&mut self, index: HeapIndex) -> Option<&mut T> {
+        if index.0 >= self.checkpoint {
+            Some(&mut self.items[index.0])
+        } else {
+            None
+        }
+    }
+
+    /// Returns a mutable borrow of the item at index.
+    /// If the item exists in the backing heap, it is automatically cloned and inserted in this heap.
+    /// The index is automatically updated to the new item in this case.
+    pub fn make_mut(&mut self, index: &mut HeapIndex) -> &mut T {
+        if index.0 < self.checkpoint {
+            let item = self.items[index.0].clone();
+            self.items.push(item);
+            *index = HeapIndex(self.items.len() - 1);
+        }
+        &mut self.items[index.0]
+    }
+}

--- a/zkvm/src/utreexo/mod.rs
+++ b/zkvm/src/utreexo/mod.rs
@@ -9,4 +9,10 @@ mod tests;
 
 // Public API
 pub use self::forest::{Catchup, Forest, UtreexoError, WorkForest};
-pub use self::path::{NodeHasher, Path, Position, Proof};
+pub use self::path::{Path, Position, Proof};
+pub use super::merkle::Hasher;
+
+/// Utreexo-labeled hasher.
+pub fn utreexo_hasher<T: super::merkle::MerkleItem>() -> Hasher<T> {
+    Hasher::new(b"ZkVM.utreexo")
+}

--- a/zkvm/src/utreexo/mod.rs
+++ b/zkvm/src/utreexo/mod.rs
@@ -1,8 +1,8 @@
 //! Implementation of a utxo accumulator inspired by Tadge Dryja's Utreexo design,
 //! with small differences in normalization algorithm.
 mod forest;
-mod path;
 mod heap;
+mod path;
 
 #[cfg(test)]
 mod tests;

--- a/zkvm/src/utreexo/mod.rs
+++ b/zkvm/src/utreexo/mod.rs
@@ -9,8 +9,8 @@ mod tests;
 
 // Public API
 pub use self::forest::{Catchup, Forest, UtreexoError, WorkForest};
-pub use self::path::{Proof};
-pub use super::merkle::{Hasher};
+pub use self::path::Proof;
+pub use super::merkle::Hasher;
 
 /// Utreexo-labeled hasher.
 pub fn utreexo_hasher<T: super::merkle::MerkleItem>() -> Hasher<T> {

--- a/zkvm/src/utreexo/mod.rs
+++ b/zkvm/src/utreexo/mod.rs
@@ -9,8 +9,8 @@ mod tests;
 
 // Public API
 pub use self::forest::{Catchup, Forest, UtreexoError, WorkForest};
-pub use self::path::{Path, Position, Proof};
-pub use super::merkle::Hasher;
+pub use self::path::{Proof};
+pub use super::merkle::{Hasher};
 
 /// Utreexo-labeled hasher.
 pub fn utreexo_hasher<T: super::merkle::MerkleItem>() -> Hasher<T> {

--- a/zkvm/src/utreexo/mod.rs
+++ b/zkvm/src/utreexo/mod.rs
@@ -2,7 +2,7 @@
 //! with small differences in normalization algorithm.
 mod forest;
 mod path;
-//mod serialization;
+mod heap;
 
 #[cfg(test)]
 mod tests;

--- a/zkvm/src/utreexo/path.rs
+++ b/zkvm/src/utreexo/path.rs
@@ -1,10 +1,8 @@
 use serde::{Deserialize, Serialize};
 
 use super::super::encoding::{self, Encodable};
-use crate::merkle::Hash;
+use crate::merkle::Path;
 
-/// Absolute position of an item in the tree.
-pub type Position = u64;
 
 /// Proof of inclusion in the Utreexo accumulator.
 /// Transient items (those that were inserted before the forest is normalized)
@@ -17,72 +15,12 @@ pub enum Proof {
     Committed(Path),
 }
 
-/// Merkle proof of inclusion of a node in a `Forest`.
-/// The exact tree is determined by the `position`, an absolute position of the item
-/// within the set of all items in the forest.
-/// Neighbors are counted from lowest to the highest.
-/// Left/right position of the neighbor is determined by the appropriate bit in `position`.
-/// (Lowest bit=1 means the first neighbor is to the left of the node.)
-/// `path` is None if this proof is for a newly added item that has no merkle path yet.
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct Path {
-    pub(super) position: Position,
-    pub(super) neighbors: Vec<Hash>,
-}
-
-#[derive(Copy, Clone, PartialEq, Debug)]
-pub(super) enum Side {
-    Left,
-    Right,
-}
-
 impl Proof {
     /// Returns a reference to a path if this proof contains one.
     pub fn path(&self) -> Option<&Path> {
         match self {
             Proof::Transient => None,
             Proof::Committed(p) => Some(p),
-        }
-    }
-}
-
-impl Side {
-    /// Orders (current, neighbor) pair of nodes as (left, right)
-    /// Alternative meaning in context of a path traversal: orders (left, right) pair of nodes as (main, neighbor)
-    pub(super) fn order<T>(self, a: T, b: T) -> (T, T) {
-        match self {
-            Side::Left => (a, b),
-            Side::Right => (b, a),
-        }
-    }
-
-    fn from_bit(bit: u8) -> Self {
-        match bit {
-            0 => Side::Left,
-            _ => Side::Right,
-        }
-    }
-}
-
-impl Default for Path {
-    fn default() -> Path {
-        Path {
-            position: 0,
-            neighbors: Vec::new(),
-        }
-    }
-}
-
-impl Path {
-    pub(super) fn iter(
-        &self,
-    ) -> impl DoubleEndedIterator<Item = (Side, &Hash)> + ExactSizeIterator {
-        self.directions().zip(self.neighbors.iter())
-    }
-    fn directions(&self) -> Directions {
-        Directions {
-            position: self.position,
-            depth: self.neighbors.len(),
         }
     }
 }
@@ -105,63 +43,5 @@ impl Encodable for Proof {
             Proof::Transient => 1,
             Proof::Committed(path) => 1 + path.serialized_length(),
         }
-    }
-}
-
-impl Encodable for Path {
-    fn encode(&self, buf: &mut Vec<u8>) {
-        encoding::write_u64(self.position, buf);
-        encoding::write_size(self.neighbors.len(), buf);
-        for hash in self.neighbors.iter() {
-            encoding::write_bytes(&hash[..], buf);
-        }
-    }
-
-    fn serialized_length(&self) -> usize {
-        return 8 + 4 + 32 * self.neighbors.len();
-    }
-}
-
-/// Simialr to Path, but does not contain neighbors - only left/right directions
-/// as indicated by the bits in the `position`.
-#[derive(Copy, Clone, PartialEq, Debug)]
-pub(super) struct Directions {
-    pub(super) position: Position,
-    pub(super) depth: usize,
-}
-
-impl ExactSizeIterator for Directions {
-    fn len(&self) -> usize {
-        self.depth
-    }
-}
-
-impl Iterator for Directions {
-    type Item = Side;
-    fn next(&mut self) -> Option<Self::Item> {
-        if self.depth == 0 {
-            return None;
-        }
-        let side = Side::from_bit((self.position & 1) as u8);
-        // kick out the lowest bit and shrink the depth
-        self.position >>= 1;
-        self.depth -= 1;
-        Some(side)
-    }
-    fn size_hint(&self) -> (usize, Option<usize>) {
-        (self.len(), Some(self.len()))
-    }
-}
-
-impl DoubleEndedIterator for Directions {
-    fn next_back(&mut self) -> Option<Self::Item> {
-        if self.depth == 0 {
-            return None;
-        }
-        self.depth -= 1;
-        // Note: we do not mask out the bit in `position` because we don't expose it.
-        // The bit is ignored implicitly by having the depth decremented.
-        let side = Side::from_bit(((self.position >> self.depth) & 1) as u8);
-        Some(side)
     }
 }

--- a/zkvm/src/utreexo/path.rs
+++ b/zkvm/src/utreexo/path.rs
@@ -3,7 +3,6 @@ use serde::{Deserialize, Serialize};
 use super::super::encoding::{self, Encodable};
 use crate::merkle::Path;
 
-
 /// Proof of inclusion in the Utreexo accumulator.
 /// Transient items (those that were inserted before the forest is normalized)
 /// do not have merkle paths and therefore come with a special `Proof::Transient`.

--- a/zkvm/src/utreexo/path.rs
+++ b/zkvm/src/utreexo/path.rs
@@ -1,15 +1,7 @@
-use core::marker::PhantomData;
-use merlin::Transcript;
 use serde::{Deserialize, Serialize};
 
 use super::super::encoding::{self, Encodable};
-use crate::merkle::{Hash, MerkleItem};
-
-/// Precomputed hash instance for computing Utreexo trees.
-pub struct NodeHasher<M: MerkleItem> {
-    t: Transcript,
-    phantom: PhantomData<M>,
-}
+use crate::merkle::Hash;
 
 /// Absolute position of an item in the tree.
 pub type Position = u64;
@@ -42,49 +34,6 @@ pub struct Path {
 pub(super) enum Side {
     Left,
     Right,
-}
-
-impl<M: MerkleItem> Clone for NodeHasher<M> {
-    fn clone(&self) -> Self {
-        Self {
-            t: self.t.clone(),
-            phantom: self.phantom,
-        }
-    }
-}
-
-impl<M: MerkleItem> NodeHasher<M> {
-    /// Creates a new hasher instance.
-    pub fn new() -> Self {
-        NodeHasher {
-            t: Transcript::new(b"ZkVM.utreexo"),
-            phantom: PhantomData,
-        }
-    }
-
-    pub(super) fn leaf(&self, item: &M) -> Hash {
-        let mut t = self.t.clone();
-        item.commit(&mut t);
-        let mut hash = Hash::default();
-        t.challenge_bytes(b"merkle.leaf", &mut hash);
-        hash
-    }
-
-    pub(super) fn intermediate(&self, left: &Hash, right: &Hash) -> Hash {
-        let mut t = self.t.clone();
-        t.append_message(b"L", &left);
-        t.append_message(b"R", &right);
-        let mut hash = Hash::default();
-        t.challenge_bytes(b"merkle.node", &mut hash);
-        hash
-    }
-
-    pub(super) fn empty(&self) -> Hash {
-        let mut t = self.t.clone();
-        let mut hash = Hash::default();
-        t.challenge_bytes(b"merkle.empty", &mut hash);
-        hash
-    }
 }
 
 impl Proof {

--- a/zkvm/src/utreexo/tests.rs
+++ b/zkvm/src/utreexo/tests.rs
@@ -11,7 +11,7 @@ impl MerkleItem for u64 {
 
 #[test]
 fn empty_utreexo() {
-    let hasher = NodeHasher::<u64>::new();
+    let hasher = utreexo_hasher::<u64>();
     let forest0 = Forest::new();
     assert_eq!(
         forest0.root(&hasher),
@@ -21,7 +21,7 @@ fn empty_utreexo() {
 
 #[test]
 fn transient_items_utreexo() {
-    let hasher = NodeHasher::new();
+    let hasher = utreexo_hasher();
     let forest0 = Forest::new();
 
     let (_forest1, _catchup) = forest0
@@ -53,7 +53,7 @@ fn transient_items_utreexo() {
 
 #[test]
 fn insert_to_utreexo() {
-    let hasher = NodeHasher::new();
+    let hasher = utreexo_hasher();
     let forest0 = Forest::new();
     let (forest1, catchup1) = forest0
         .update(&hasher, |forest| {
@@ -91,7 +91,7 @@ fn insert_to_utreexo() {
 
 #[test]
 fn transaction_success() {
-    let hasher = NodeHasher::new();
+    let hasher = utreexo_hasher();
     let forest0 = Forest::new();
     let (forest1, catchup1) = forest0
         .update(&hasher, |forest| {
@@ -165,7 +165,7 @@ fn transaction_success() {
 
 #[test]
 fn transaction_fail() {
-    let hasher = NodeHasher::new();
+    let hasher = utreexo_hasher();
     let forest0 = Forest::new();
     let (forest1, catchup1) = forest0
         .update(&hasher, |forest| {
@@ -235,7 +235,7 @@ fn transaction_fail() {
 #[test]
 fn insert_and_delete_utreexo() {
     let n = 6u64;
-    let hasher = NodeHasher::new();
+    let hasher = utreexo_hasher();
     let forest0 = Forest::new();
     let (forest1, catchup1) = forest0
         .update(&hasher, |forest| {
@@ -269,7 +269,7 @@ fn insert_and_delete_utreexo() {
         new_set: &[M],
         upd: impl FnOnce(&mut WorkForest),
     ) -> (Forest, Catchup) {
-        let hasher = NodeHasher::<M>::new();
+        let hasher = utreexo_hasher::<M>();
         let (forest2, catchup2) = forest
             .update(&hasher, |forest| {
                 upd(forest);


### PR DESCRIPTION
Important: this replaces broken encoding for Predicate CallProof, reusing the same format as for Utreexo proofs. Previous implementation did not have explicit length of neighbors (those were derived from the lower bits of the position, ignoring high zero bits).