### PR TITLE
zkvm: mempool with sort-by-feerate and CPFP

### DIFF
--- a/zkvm/src/blockchain/errors.rs
+++ b/zkvm/src/blockchain/errors.rs
@@ -31,4 +31,8 @@ pub enum BlockchainError {
     /// Occurs when utreexo operation failed.
     #[fail(display = "Utreexo operation failed.")]
     UtreexoError(UtreexoError),
+
+    /// Occurs when a transaction attempts to spend a non-existent unconfirmed output.
+    #[fail(display = "Transaction attempts to spend a non-existent unconfirmed output.")]
+    InvalidUnconfirmedOutput,
 }

--- a/zkvm/src/blockchain/errors.rs
+++ b/zkvm/src/blockchain/errors.rs
@@ -35,4 +35,16 @@ pub enum BlockchainError {
     /// Occurs when a transaction attempts to spend a non-existent unconfirmed output.
     #[fail(display = "Transaction attempts to spend a non-existent unconfirmed output.")]
     InvalidUnconfirmedOutput,
+
+    /// Occurs when a transaction does not have a competitive fee and cannot be included in mempool.
+    #[fail(
+        display = "Transaction has low fee relative to all the other transactions in the mempool."
+    )]
+    MempoolRejectedLowFee,
+
+    /// Occurs when a transaction spends too long chain of unconfirmed outputs, making it expensive to handle.
+    #[fail(display = "Transaction spends too long chain of unconfirmed outputs.")]
+    MempoolRejectedTooDeep,
 }
+
+// TODO: add mempool error enum.

--- a/zkvm/src/blockchain/mempool.rs
+++ b/zkvm/src/blockchain/mempool.rs
@@ -1,0 +1,392 @@
+//! "Memory pool" is a data structure for managing _unconfirmed transactions_.
+//! It decides which transactions to accept from other peers and relay further.
+//!
+//! Generally, transactions are sorted by _feerate_: the amount of fees paid per byte.
+//! What if transaction does not pay high enough fee? At best it’s not going to be relayed anywhere.
+//! At worst, it’s going to be relayed and dropped by some nodes, and relayed again by others, etc.
+//!
+//! There are three ways out of this scenario:
+//!
+//! 1. Simply wait longer until the transaction gets published.
+//!    Once a year, when everyone goes on vacation, the network gets less loaded and your transaction may get its slot.
+//! 2. Replace the transaction with another one, with a higher fee. This is known as "replace-by-fee" (RBF).
+//!    This has a practical downside: one need to re-communicate blinding factors with the recipient when making an alternative tx.
+//! 3. Create a chained transaction that pays a higher fee to cover for itself and for the parent.
+//!    This is known as "child pays for parent" (CPFP).
+//!
+//! In this implementation we are implementing a CPFP strategy
+//! to make prioritization more accurate and allow users "unstuck" their transactions.
+//!
+use crate::ContractID; //, TxEntry, TxHeader, TxLog, VerifiedTx};
+use crate::FeeRate;
+use crate::VerifiedTx;
+use core::cell::RefCell;
+use std::borrow::Borrow;
+use std::collections::HashMap;
+use std::ops::{Deref, DerefMut};
+use std::rc::Rc;
+
+use super::errors::BlockchainError;
+use super::state::BlockchainState;
+use crate::merkle::Hasher;
+use crate::tx::{TxEntry, TxLog};
+use crate::utreexo;
+
+/// Main API to the memory pool.
+pub struct Mempool<Tx: MempoolTx> {
+    /// Current blockchain state.
+    state: BlockchainState,
+
+    /// State of confirmed outputs.
+    work_utreexo: utreexo::WorkForest,
+
+    /// State of available outputs.
+    utxos: HashMap<ContractID, UtxoStatus<Tx>>,
+
+    /// Tx with the lowest feerate. None when the mempool is empty.
+    lowest_tx: Option<Ref<Tx>>,
+
+    /// Total size of the mempool.
+    current_size: usize,
+
+    /// Maximum allowed size of the mempool.
+    max_size: usize,
+
+    /// Current timestamp.
+    timestamp_ms: u64,
+}
+
+/// Trait for the items in the mempool.
+pub trait MempoolTx {
+    /// Returns a reference to a verified transaction
+    fn verified_tx(&self) -> &VerifiedTx;
+
+    /// Returns a collection of Utreexo proofs for the transaction.
+    fn utreexo_proofs(&self) -> &[utreexo::Proof];
+
+    fn txlog(&self) -> &TxLog {
+        &self.verified_tx().log
+    }
+
+    fn feerate(&self) -> FeeRate {
+        self.verified_tx().feerate
+    }
+}
+
+/// Small per-peer LRU buffer where low-fee transactions are parked
+/// until they are either kicked out, or get promoted to mempool due to CPFP.
+/// All the changes to mempool are made through this peer pool, so
+/// the transactions can be parked and unparked from there.
+pub struct Peerpool {
+    // TODO: add the peer pool later and for now add txs directly to mempool.
+}
+
+/// Reference-counted reference to a transaction.
+struct Ref<Tx: MempoolTx> {
+    inner: Rc<RefCell<Node<Tx>>>,
+}
+
+enum Input<Tx: MempoolTx> {
+    /// Input is marked as confirmed - we don't really care where in utreexo it is.
+    Confirmed,
+    /// Parent tx and an index in parent.outputs list.
+    Unconfirmed(Ref<Tx>, usize),
+}
+
+enum Output<Tx: MempoolTx> {
+    /// Currently unoccupied output.
+    Unspent,
+
+    /// Child transaction and an index in child.inputs list.
+    Spent(Ref<Tx>, usize),
+}
+
+struct Node<Tx: MempoolTx> {
+    tx: Tx,
+
+    total_feerate: FeeRate,
+    // list of inputs - always fully initialized
+    inputs: Vec<Input<Tx>>,
+    // list of outputs - always fully initialized
+    outputs: Vec<Output<Tx>>,
+
+    // doubly-linked list to lower-feerate and higher-feerate txs.
+    // ø ø - tx is outside the mempool (e.g. in PeerPool)
+    // x ø - tx is the highest-paying
+    // x x - tx is in the middle of a list
+    // ø x - tx is the lowest-paying
+    lower: Option<Ref<Tx>>,
+    higher: Option<Ref<Tx>>,
+}
+
+impl<Tx: MempoolTx> Mempool<Tx> {
+    /// Creates a new mempool with the given size limit, timestamp
+    pub fn new(max_size: usize, state: BlockchainState, timestamp_ms: u64) -> Self {
+        let work_utreexo = state.utreexo.work_forest();
+        Mempool {
+            state,
+            work_utreexo,
+            utxos: HashMap::new(),
+            lowest_tx: None,
+            current_size: 0,
+            max_size,
+            timestamp_ms,
+        }
+    }
+
+    /// The fee paid by an incoming tx must cover with the minimum feerate both
+    /// the size of the incoming tx and the size of the evicted tx:
+    ///
+    /// new_fee ≥ min_feerate * (evicted_size + new_size).
+    ///
+    /// This method returns the effective feerate of the lowest-priority tx,
+    /// which also contains the total size that must be accounted for.
+    pub fn min_feerate(&self) -> FeeRate {
+        self.lowest_tx
+            .as_ref()
+            .map(|r| r.borrow().effective_feerate())
+            .unwrap_or(FeeRate::zero())
+    }
+
+    /// Add a transaction.
+    /// Fails if the transaction attempts to spend a non-existent output.
+    /// Does not check the feerate.
+    fn append(&mut self, item: Tx) -> Result<(), BlockchainError> {
+        unimplemented!()
+    }
+
+    /// Removes the lowest-feerate transactions to reduce the size of the mempool to the maximum allowed.
+    /// User may provide a buffer that implements Extend to collect and inspect all evicted transactions.
+    fn compact(&mut self, evicted_txs: impl core::iter::Extend<Tx>) {
+        unimplemented!()
+    }
+}
+
+impl<Tx: MempoolTx> Node<Tx> {
+    fn self_feerate(&self) -> FeeRate {
+        self.tx.feerate()
+    }
+
+    fn effective_feerate(&self) -> FeeRate {
+        core::cmp::max(self.self_feerate(), self.total_feerate)
+    }
+
+    fn into_ref(self) -> Ref<Tx> {
+        Ref {
+            inner: Rc::new(RefCell::new(self)),
+        }
+    }
+}
+
+/// The fee paid by an incoming tx must cover with the minimum feerate both
+/// the size of the incoming tx and the size of the evicted tx:
+///
+/// `new_fee > min_feerate * (evicted_size + new_size)`
+///
+/// This method returns the effective feerate of the lowest-priority tx,
+/// which also contains the total size that must be accounted for.
+///
+/// This is equivalent to:
+///
+/// `new_fee*evicted_size > min_fee * (evicted_size + new_size)`
+///
+fn is_feerate_sufficient(feerate: FeeRate, min_feerate: FeeRate) -> bool {
+    let evicted_size = min_feerate.size() as u64;
+    feerate.fee() * evicted_size > min_feerate.fee() * (evicted_size + (feerate.size() as u64))
+}
+
+/// Attempts to apply transaction changes
+fn apply_tx<'a, 'b, Tx: MempoolTx>(
+    tx: Tx,
+    utreexo: &utreexo::Forest,
+    utxo_view: &mut UtxoView<'a, 'b, Tx>,
+    hasher: &Hasher<ContractID>,
+) -> Result<Ref<Tx>, BlockchainError> {
+    let mut utreexo_proofs = tx.utreexo_proofs().iter();
+
+    // Start by collecting the inputs and
+    let inputs = tx
+        .txlog()
+        .inputs()
+        .map(|cid| {
+            let utxoproof = utreexo_proofs
+                .next()
+                .ok_or(BlockchainError::UtreexoProofMissing)?;
+
+            match (utxo_view.get(cid).into_option(), utxoproof) {
+                (Some(UtxoStatus::UnconfirmedUnspent(srctx, i)), _proof) => {
+                    Ok(Input::Unconfirmed(srctx.clone(), *i))
+                }
+                (Some(_), _proof) => Err(BlockchainError::InvalidUnconfirmedOutput),
+                (None, utreexo::Proof::Committed(path)) => {
+                    // check the path
+                    utreexo
+                        .verify(cid, path, hasher)
+                        .map_err(|e| BlockchainError::UtreexoError(e))?;
+                    Ok(Input::Confirmed)
+                }
+                (None, utreexo::Proof::Transient) => Err(BlockchainError::UtreexoProofMissing),
+            }
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+
+    let outputs = tx
+        .txlog()
+        .outputs()
+        .map(|_| Output::Unspent)
+        .collect::<Vec<_>>();
+
+    let new_ref = Node {
+        total_feerate: tx.feerate(),
+        inputs,
+        outputs,
+        lower: None, // will be connected by the caller
+        higher: None,
+        tx,
+    }
+    .into_ref();
+
+    // At this point the spending was checked, so we can do mutating changes.
+    // 1. If we are spending an unconfirmed tx in the front of the view - we can link it back to
+    //    its child. If it's in the back, we should not link.
+    // 2. For each input we should store a "spent" status into the UtxoView.
+    // 3. for each output we should store an "unspent" status into the utxoview.
+    for (input_index, cid) in new_ref.borrow().tx.txlog().inputs().enumerate() {
+        // if the spent output is unconfirmed in the front of the view - modify it to link.
+        if let Some(UtxoStatus::UnconfirmedUnspent(srctx, output_index)) =
+            utxo_view.get(cid).front_value()
+        {
+            srctx.borrow_mut().outputs[*output_index] = Output::Spent(new_ref.clone(), input_index);
+        }
+    }
+
+    for (input_status, cid) in new_ref
+        .borrow()
+        .inputs
+        .iter()
+        .zip(new_ref.borrow().tx.txlog().inputs())
+    {
+        let status = match input_status {
+            Input::Confirmed => UtxoStatus::ConfirmedSpent,
+            Input::Unconfirmed(_, _) => UtxoStatus::UnconfirmedSpent,
+        };
+        utxo_view.set(*cid, status);
+    }
+
+    for (i, cid) in new_ref
+        .borrow()
+        .tx
+        .txlog()
+        .outputs()
+        .map(|c| c.id())
+        .enumerate()
+    {
+        utxo_view.set(cid, UtxoStatus::UnconfirmedUnspent(new_ref.clone(), i));
+    }
+
+    Ok(new_ref)
+}
+
+/// Status of the utxo cached by the mempool
+enum UtxoStatus<Tx: MempoolTx> {
+    /// unspent output originating from the i'th output in the given unconfirmed tx
+    UnconfirmedUnspent(Ref<Tx>, usize),
+
+    /// unconfirmed output is spent by another unconfirmed tx
+    UnconfirmedSpent,
+
+    /// spent output stored in utreexo
+    ConfirmedSpent,
+}
+
+struct UtxoView<'a, 'b: 'a, Tx: MempoolTx> {
+    hashmap: &'a mut HashMap<ContractID, UtxoStatus<Tx>>,
+    backing: Option<&'b HashMap<ContractID, UtxoStatus<Tx>>>,
+}
+
+impl<Tx: MempoolTx> UtxoStatus<Tx> {
+    fn is_unconfirmed_spent(&self) -> bool {
+        match self {
+            UtxoStatus::UnconfirmedSpent => true,
+            _ => false,
+        }
+    }
+}
+
+impl<Tx: MempoolTx> Ref<Tx> {
+    fn borrow(&self) -> impl Deref<Target = Node<Tx>> + '_ {
+        RefCell::borrow(&self.inner)
+    }
+
+    fn borrow_mut(&self) -> impl DerefMut<Target = Node<Tx>> + '_ {
+        RefCell::borrow_mut(&self.inner)
+    }
+
+    fn clone(&self) -> Self {
+        Ref {
+            inner: self.inner.clone(),
+        }
+    }
+
+    // Removes all back references from parent to children recursively,
+    // and also the linkedlist references.
+    // The only references remaining are forward references from children to parents,
+    // that are auto-destroyed in reverse order when children are dropped.
+    fn unlink(&self) {
+        for out in self.borrow().outputs.iter() {
+            if let Output::Spent(child, _) = out {
+                child.unlink()
+            }
+        }
+        let mut tx = self.borrow_mut();
+        for out in tx.outputs.iter_mut() {
+            *out = Output::Unspent;
+        }
+        tx.lower = None;
+        tx.higher = None;
+    }
+}
+
+enum ViewResult<T> {
+    None,
+    Front(T),
+    Backing(T),
+}
+
+impl<T> ViewResult<T> {
+    fn into_option(self) -> Option<T> {
+        match self {
+            ViewResult::None => None,
+            ViewResult::Front(x) => Some(x),
+            ViewResult::Backing(x) => Some(x),
+        }
+    }
+
+    fn front_value(self) -> Option<T> {
+        match self {
+            ViewResult::Front(x) => Some(x),
+            _ => None,
+        }
+    }
+}
+
+impl<'a, 'b: 'a, Tx: MempoolTx> UtxoView<'a, 'b, Tx> {
+    fn get(&self, contract_id: &ContractID) -> ViewResult<&UtxoStatus<Tx>> {
+        let front = self.hashmap.get(contract_id);
+        if let Some(x) = front {
+            ViewResult::Front(x)
+        } else if let Some(x) = self.backing.and_then(|b| b.get(contract_id)) {
+            ViewResult::Backing(x)
+        } else {
+            ViewResult::None
+        }
+    }
+    fn set(&mut self, contract_id: ContractID, status: UtxoStatus<Tx>) -> Option<UtxoStatus<Tx>> {
+        // If backing is None and we are storing UnconfirmedSpent, we simply remove the existing item.
+        // In such case we are operating on the root storage, where we don't even need to store the spent status of the utxos.
+        if self.backing.is_none() && status.is_unconfirmed_spent() {
+            return self.hashmap.remove(&contract_id);
+        }
+        self.hashmap.insert(contract_id, status)
+    }
+}

--- a/zkvm/src/blockchain/mod.rs
+++ b/zkvm/src/blockchain/mod.rs
@@ -10,4 +10,5 @@ mod tests;
 
 pub use self::block::*;
 pub use self::errors::*;
+pub use self::mempool::*;
 pub use self::state::*;

--- a/zkvm/src/blockchain/mod.rs
+++ b/zkvm/src/blockchain/mod.rs
@@ -2,6 +2,7 @@
 
 mod block;
 mod errors;
+mod mempool;
 mod state;
 
 #[cfg(test)]

--- a/zkvm/src/blockchain/state.rs
+++ b/zkvm/src/blockchain/state.rs
@@ -263,7 +263,7 @@ where
 }
 
 /// Checks the tx header for consistency with the block header.
-fn check_tx_header(
+pub fn check_tx_header(
     tx_header: &TxHeader,
     timestamp_ms: u64,
     block_version: u64,

--- a/zkvm/src/fees.rs
+++ b/zkvm/src/fees.rs
@@ -12,7 +12,7 @@ pub struct CheckedFee {
 }
 
 /// Fee rate is a ratio of the transaction fee to its size.
-#[derive(Copy, Clone, Debug, Serialize, Deserialize)]
+#[derive(Copy, Clone, Default, Debug, Serialize, Deserialize)]
 pub struct FeeRate {
     fee: u64,
     size: u64,
@@ -24,6 +24,11 @@ pub fn fee_flavor() -> Scalar {
 }
 
 impl FeeRate {
+    /// Creates a new zero feerate
+    pub fn zero() -> Self {
+        FeeRate::default()
+    }
+
     /// Creates a new fee rate from a given fee and size.
     pub fn new(fee: CheckedFee, size: usize) -> Self {
         FeeRate {

--- a/zkvm/src/fees.rs
+++ b/zkvm/src/fees.rs
@@ -38,15 +38,25 @@ impl FeeRate {
     }
 
     /// Combines the fee rate with another fee rate, adding up the fees and sizes.
-    pub fn combine(&self, other: FeeRate) -> Self {
+    pub fn combine(self, other: FeeRate) -> Self {
         FeeRate {
             fee: self.fee + other.fee,
             size: self.size + other.size,
         }
     }
 
+    /// Discounts the fee and the size by a given factor.
+    /// E.g. feerate 100/1200 discounted by 2 gives 50/600.
+    /// Same ratio, but lower weight when combined with other feerates.
+    pub fn discount(mut self, parts: usize) -> Self {
+        let parts = parts as u64;
+        self.fee /= parts;
+        self.size /= parts;
+        self
+    }
+
     /// Converts the fee rate to a floating point number.
-    pub fn to_f64(&self) -> f64 {
+    pub fn to_f64(self) -> f64 {
         (self.fee as f64) / (self.size as f64)
     }
 

--- a/zkvm/src/lib.rs
+++ b/zkvm/src/lib.rs
@@ -36,6 +36,7 @@ pub use self::constraints::{Commitment, CommitmentWitness, Constraint, Expressio
 pub use self::contract::{Anchor, Contract, ContractID, PortableItem};
 pub use self::encoding::Encodable;
 pub use self::errors::VMError;
+pub use self::fees::FeeRate;
 pub use self::merkle::{Hash, MerkleItem, MerkleTree};
 pub use self::ops::{Instruction, Opcode};
 pub use self::predicate::{Predicate, PredicateTree};

--- a/zkvm/src/merkle.rs
+++ b/zkvm/src/merkle.rs
@@ -392,7 +392,7 @@ impl Encodable for Path {
     }
 }
 
-/// Simialr to Path, but does not contain neighbors - only left/right directions
+/// Similar to Path, but does not contain neighbors - only left/right directions
 /// as indicated by the bits in the `position`.
 #[derive(Copy, Clone, PartialEq, Debug)]
 pub struct Directions {

--- a/zkvm/src/program.rs
+++ b/zkvm/src/program.rs
@@ -175,8 +175,9 @@ impl Program {
     def_op!(issue, Issue, "issue");
     def_op!(borrow, Borrow, "borrow");
     def_op!(retire, Retire, "retire");
-
     def_op!(cloak, Cloak, usize, usize, "cloak:m:n");
+    def_op!(fee, Fee, "fee");
+
     def_op!(input, Input, "input");
     def_op!(output, Output, usize, "output:k");
     def_op!(contract, Contract, usize, "contract:k");

--- a/zkvm/src/tx.rs
+++ b/zkvm/src/tx.rs
@@ -268,6 +268,22 @@ impl TxLog {
     pub fn push(&mut self, item: TxEntry) {
         self.0.push(item);
     }
+
+    /// Iterator over the input entries
+    pub fn inputs(&self) -> impl Iterator<Item = &ContractID> {
+        self.0.iter().filter_map(|entry| match entry {
+            TxEntry::Input(contract_id) => Some(contract_id),
+            _ => None,
+        })
+    }
+
+    /// Iterator over the output entries
+    pub fn outputs(&self) -> impl Iterator<Item = &Contract> {
+        self.0.iter().filter_map(|entry| match entry {
+            TxEntry::Output(contract) => Some(contract),
+            _ => None,
+        })
+    }
 }
 
 impl From<Vec<TxEntry>> for TxLog {


### PR DESCRIPTION
This adds a new mempool design with the following features:

1. Memory pool is configured with a **maximum size** (bytes) and **maximum depth** of transactions. Depth limits DoS risk inflicted by recursive updates.
2. Transactions are **ordered by** feerate. When mempool is full, new transactions must have a **sufficient feerate** to replace existing lowest-feerate tx.
3. Transaction's **effective feerate** is computed accounting for descendents' feerate. This implements child-pays-for-parent (CPFP) policy.
4. Transactions with insufficient feerate are parked in **peer pools**, short per-peer buffers. This permits keeping around insufficient-fee parent until a sufficient-fee child arrives. Peerpool transactions are not relayed and evicted on LRU basis.
5. Simple iterator API allows using arbitrary set-reconciliation protocols to minimize traffic between peers.

Note: this is WIP, a few things are not finished up yet.
