### PR TITLE
zkvm: redesigned fee operation to return WideValue and save a rangeproof

### DIFF
--- a/zkvm/docs/zkvm-spec.md
+++ b/zkvm/docs/zkvm-spec.md
@@ -926,7 +926,7 @@ Code | Instruction                | Stack diagram                              |
 0x16 | [`borrow`](#borrow)        |         _qty flv_ → _–V +V_                | Modifies [CS](#constraint-system)
 0x17 | [`retire`](#retire)        |           _value_ → ø                      | Modifies [CS](#constraint-system), [tx log](#transaction-log)
 0x18 | [`cloak:m:n`](#cloak)      | _widevalues commitments_ → _values_        | Modifies [CS](#constraint-system)
-0x19 | [`fee`](#fee)              |       _value qty_ → ø                      | Modifies [tx log](#transaction-log)
+0x19 | [`fee`](#fee)              |             _qty_ → _widevalue_            | Modifies [CS](#constraint-system), [tx log](#transaction-log)
  |                                |                                            |
  |     [**Contracts**](#contract-instructions)        |                        |
 0x1a | [`input`](#input)          |      _prevoutput_ → _contract_             | Modifies [tx log](#transaction-log)
@@ -1297,18 +1297,17 @@ Immediate data `m` and `n` are encoded as two [LE32](#le32)s.
 
 #### fee
 
-_value qty_ **fee** → ø
+_qty_ **fee** → _widevalue_
 
-1. Pops an 8-byte [string](#string-type) `qty` from the stack and decodes it as [LE64](#le64) integer.
-2. Pops [value](#value-type) from the stack.
-3. Checks that value.qty is unblinded commitment to `qty` and value.flv is unblinded commitment to zero.
-4. Adds a [fee entry](#fee-entry) to the [transaction log](#transaction-log).
-
-The checks are performed with group elements directly, without any changes to a [constraint system](#constraint-system).
+1. Pops an 4-byte [string](#string-type) `qty` from the stack and decodes it as [LE32](#le64) integer.
+2. Checks that `qty` is less or equal to `2^24`.
+3. Pushes [wide value](#wide-value-type) `–V`, with quantity variable constrained to `-qty` and with flavor constrained to 0.
+   Both variables are allocated from a single multiplier.
+4. Adds a [fee entry](#fee-entry) to the [transaction log](#transaction-log) with the quantity `qty`.
 
 Fails if:
-* value.qty does not match unblinded `qty`,
-* value.flv is not an unblinded commitment to 0.
+* `qty` is exceeding `2^24`.
+
 
 
 

--- a/zkvm/src/debug.rs
+++ b/zkvm/src/debug.rs
@@ -52,7 +52,8 @@ impl String {
             String::Commitment(commitment) => write!(f, "push:{:?}", commitment),
             String::Scalar(scalar_witness) => write!(f, "push:{:?}", scalar_witness),
             String::Output(contract) => write!(f, "push:{:?}", contract),
-            String::Int(n) => write!(f, "push:{:?}", n),
+            String::U64(n) => write!(f, "push:{:?}", n),
+            String::U32(n) => write!(f, "push:{:?}", n),
         }
     }
 }

--- a/zkvm/src/errors.rs
+++ b/zkvm/src/errors.rs
@@ -74,7 +74,11 @@ pub enum VMError {
 
     /// This error occurs when an instruction requires a u64 integer.
     #[fail(display = "Item is not a LE64 integer.")]
-    TypeNotInt,
+    TypeNotU64,
+
+    /// This error occurs when an instruction requires a u32 integer.
+    #[fail(display = "Item is not a LE32 integer.")]
+    TypeNotU32,
 
     /// This error occurs when an instruction requires a program item.
     #[fail(display = "Item is not a program item.")]

--- a/zkvm/src/types.rs
+++ b/zkvm/src/types.rs
@@ -72,7 +72,10 @@ pub enum String {
     Output(Box<Contract>),
 
     /// A u64 integer.
-    Int(u64),
+    U64(u64),
+
+    /// A u32 integer.
+    U32(u32),
 }
 
 /// Represents a value of an issued asset in the VM.
@@ -208,7 +211,8 @@ impl Encodable for String {
             String::Commitment(commitment) => commitment.encoded_length(),
             String::Scalar(scalar) => scalar.encoded_length(),
             String::Output(output) => output.encoded_length(),
-            String::Int(_) => 8,
+            String::U64(_) => 8,
+            String::U32(_) => 4,
         }
     }
     /// Encodes the data item to an opaque bytestring.
@@ -219,7 +223,8 @@ impl Encodable for String {
             String::Commitment(commitment) => commitment.encode(buf),
             String::Scalar(scalar) => scalar.encode(buf),
             String::Output(contract) => contract.encode(buf),
-            String::Int(n) => encoding::write_u64(*n, buf),
+            String::U64(n) => encoding::write_u64(*n, buf),
+            String::U32(n) => encoding::write_u32(*n, buf),
         };
     }
 }
@@ -287,8 +292,20 @@ impl String {
                 let n = SliceReader::parse(&data, |r| r.read_u64())?;
                 Ok(n)
             }
-            String::Int(n) => Ok(n),
-            _ => Err(VMError::TypeNotInt),
+            String::U64(n) => Ok(n),
+            _ => Err(VMError::TypeNotU64),
+        }
+    }
+
+    /// Downcast the data item to a `u32` type.
+    pub fn to_u32(self) -> Result<u32, VMError> {
+        match self {
+            String::Opaque(data) => {
+                let n = SliceReader::parse(&data, |r| r.read_u32())?;
+                Ok(n)
+            }
+            String::U32(n) => Ok(n),
+            _ => Err(VMError::TypeNotU32),
         }
     }
 }


### PR DESCRIPTION
Fees are cleartext values paid via the `fee` instruction. Previous version of the instruction was inspecting the `Value` type, which was created by a `cloak` instruction, where a rangeproof was wasted needlessly. In this PR we reverse the order of the operations: first, the fee is borrowed and immediately written to txlog, then a `WideValue` with negative fee is left on stack to be mixed with other assets using `cloak`. This way, cloak does not need to have special support for cleartext values.