### PR TITLE
zkvm: allow dropping Program/Expression/Constraint

### DIFF
--- a/zkvm/docs/zkvm-spec.md
+++ b/zkvm/docs/zkvm-spec.md
@@ -1314,13 +1314,12 @@ Immediate data `m` and `n` are encoded as two [LE32](#le32)s.
 _qty_ **fee** → _widevalue_
 
 1. Pops an 4-byte [string](#string-type) `qty` from the stack and decodes it as [LE32](#le64) integer.
-2. Checks that `qty` is less or equal to `2^24`.
+2. Checks that `qty`  and accumulated fee is less or equal to `2^24`.
 3. Pushes [wide value](#wide-value-type) `–V`, with quantity variable constrained to `-qty` and with flavor constrained to 0.
    Both variables are allocated from a single multiplier.
 4. Adds a [fee entry](#fee-entry) to the [transaction log](#transaction-log) with the quantity `qty`.
 
-Fails if:
-* `qty` is exceeding `2^24`.
+Fails if the resulting amount of fees is exceeding `2^24`.
 
 
 

--- a/zkvm/docs/zkvm-spec.md
+++ b/zkvm/docs/zkvm-spec.md
@@ -9,6 +9,7 @@ ZkVM defines a procedural representation for blockchain transactions and the rul
     * [Concepts](#concepts)
 * [Types](#types)
     * [Copyable types](#copyable-types)
+    * [Droppable types](#droppable-types)
     * [Linear types](#linear-types)
     * [Portable types](#portable-types)
     * [String](#string-type)
@@ -146,11 +147,11 @@ transaction’s applicability to the blockchain.
 
 The items on the ZkVM stack are typed. The available types fall into two 
 categories: [copyable types](#copyable-types) and [linear types](#linear-types).
-
+All copyable types, and some linear types are [droppable](#droppable-types).
 
 ### Copyable types
 
-Copyable types can be freely copied with [`dup`](#dup) or destroyed with [`drop`](#drop):
+Copyable types can be freely copied with [`dup`](#dup).
 
 * [String](#string-type)
 * [Variable](#variable-type)
@@ -158,6 +159,19 @@ Copyable types can be freely copied with [`dup`](#dup) or destroyed with [`drop`
 Note: the [program](#program-type) is not copyable to avoid denial-of-service attacks
 via repeated execution of the same program that can be scaled exponentially while
 growing the transaction size only linearly.
+For the same reason, [expressions](#expression-type) and [constraints](#constraint-type) are
+not copyable either.
+
+
+### Droppable types
+
+Droppable types can be destroyed with [`drop`](#drop):
+
+* [String](#string-type)
+* [Program](#program-type)
+* [Variable](#variable-type)
+* [Expression](#expression-type)
+* [Constraint](#constraint-type)
 
 
 ### Linear types
@@ -967,7 +981,7 @@ _x_ **drop** → ø
 
 Drops `x` from the stack.
 
-Fails if `x` is not a [copyable type](#copyable-types).
+Fails if `x` is not a [droppable type](#droppable-types).
 
 
 #### dup

--- a/zkvm/src/errors.rs
+++ b/zkvm/src/errors.rs
@@ -28,6 +28,10 @@ pub enum VMError {
     #[fail(display = "Item is not a copyable type.")]
     TypeNotCopyable,
 
+    /// This error occurs when an instruction requires a droppable type, but a non-droppable type is encountered.
+    #[fail(display = "Item is not a droppable type.")]
+    TypeNotDroppable,
+
     /// This error occurs when an instruction requires a portable type, but a non-portable type is encountered.
     #[fail(display = "Item is not a portable type.")]
     TypeNotPortable,

--- a/zkvm/src/ops.rs
+++ b/zkvm/src/ops.rs
@@ -32,7 +32,7 @@ pub enum Instruction {
     ///
     /// Drops `x` from the stack.
     ///
-    /// Fails if `x` is not a _copyable type_.
+    /// Fails if `x` is not a _droppable type_.
     Drop,
 
     /// _x(k) … x(0)_ **dup:_k_** → _x(k) ... x(0) x(k)_
@@ -322,18 +322,16 @@ pub enum Instruction {
     /// Immediate data `m` and `n` are encoded as two _LE32_s.
     Cloak(usize, usize),
 
-    /// _value qty_ **fee** → ø
+    /// _qty_ **fee** → _widevalue_
     ///
-    /// 1. Pops an 8-byte _string_ `qty` from the stack and decodes it as _LE64_ integer.
-    /// 2. Pops _value_ from the stack.
-    /// 3. Checks that value.qty is unblinded commitment to `qty` and value.flv is unblinded commitment to zero.
-    /// 4. Adds a _fee entry_ to the _transaction log_.
-    ///
-    /// The checks are performed with group elements directly, without any changes to a _constraint system_.
+    /// 1. Pops an 4-byte _string_ `qty` from the stack and decodes it as _LE32_ integer.
+    /// 2. Checks that `qty` is less or equal to `2^24`.
+    /// 3. Pushes _wide value_ `–V`, with quantity variable constrained to `-qty` and with flavor constrained to 0.
+    ///    Both variables are allocated from a single multiplier.
+    /// 4. Adds a _fee entry_ to the _transaction log_ with the quantity `qty`.
     ///
     /// Fails if:
-    /// * value.qty does not match unblinded `qty`,
-    /// * value.flv is not an unblinded commitment to 0.
+    /// * `qty` is exceeding `2^24`.
     Fee,
 
     /// _prevoutput_ **input** → _contract_

--- a/zkvm/src/ops.rs
+++ b/zkvm/src/ops.rs
@@ -325,13 +325,12 @@ pub enum Instruction {
     /// _qty_ **fee** → _widevalue_
     ///
     /// 1. Pops an 4-byte _string_ `qty` from the stack and decodes it as _LE32_ integer.
-    /// 2. Checks that `qty` is less or equal to `2^24`.
+    /// 2. Checks that `qty`  and accumulated fee is less or equal to `2^24`.
     /// 3. Pushes _wide value_ `–V`, with quantity variable constrained to `-qty` and with flavor constrained to 0.
     ///    Both variables are allocated from a single multiplier.
     /// 4. Adds a _fee entry_ to the _transaction log_ with the quantity `qty`.
     ///
-    /// Fails if:
-    /// * `qty` is exceeding `2^24`.
+    /// Fails if the resulting amount of fees is exceeding `2^24`.
     Fee,
 
     /// _prevoutput_ **input** → _contract_

--- a/zkvm/src/types.rs
+++ b/zkvm/src/types.rs
@@ -42,7 +42,7 @@ pub enum Item {
     Constraint(Constraint),
 }
 
-/// An item on a VM stack that can be copied and dropped.
+/// An item on a VM stack that can be copied.
 #[derive(Clone, Debug)]
 pub enum CopyableItem {
     /// A data item: a text string, a commitment or a scalar
@@ -50,6 +50,25 @@ pub enum CopyableItem {
 
     /// A variable type.
     Variable(Variable),
+}
+
+/// An item on a VM stack that can be dropped.
+#[derive(Clone, Debug)]
+pub enum DroppableItem {
+    /// A data item: a text string, a commitment or a scalar
+    String(String),
+
+    /// A program item: a bytecode string for `call`/`delegate` instructions
+    Program(ProgramItem),
+
+    /// A variable type.
+    Variable(Variable),
+
+    /// An expression type.
+    Expression(Expression),
+
+    /// A constraint type.
+    Constraint(Constraint),
 }
 
 /// A data item.
@@ -178,21 +197,24 @@ impl Item {
         }
     }
 
-    /// Downcasts item to a copyable type.
-    pub fn to_copyable(self) -> Result<CopyableItem, VMError> {
-        match self {
-            Item::String(x) => Ok(CopyableItem::String(x)),
-            Item::Variable(x) => Ok(CopyableItem::Variable(x)),
-            _ => Err(VMError::TypeNotCopyable),
-        }
-    }
-
     /// Copies a copyable type when it's given as a reference.
     pub fn dup_copyable(&self) -> Result<CopyableItem, VMError> {
         match self {
             Item::String(x) => Ok(CopyableItem::String(x.clone())),
             Item::Variable(x) => Ok(CopyableItem::Variable(x.clone())),
             _ => Err(VMError::TypeNotCopyable),
+        }
+    }
+
+    /// Downcasts item to a droppable type.
+    pub fn to_droppable(self) -> Result<DroppableItem, VMError> {
+        match self {
+            Item::String(x) => Ok(DroppableItem::String(x)),
+            Item::Program(x) => Ok(DroppableItem::Program(x)),
+            Item::Variable(x) => Ok(DroppableItem::Variable(x)),
+            Item::Expression(x) => Ok(DroppableItem::Expression(x)),
+            Item::Constraint(x) => Ok(DroppableItem::Constraint(x)),
+            _ => Err(VMError::TypeNotDroppable),
         }
     }
 }

--- a/zkvm/src/vm.rs
+++ b/zkvm/src/vm.rs
@@ -199,7 +199,7 @@ where
     }
 
     fn drop(&mut self) -> Result<(), VMError> {
-        let _dropped = self.pop_item()?.to_copyable()?;
+        let _dropped = self.pop_item()?.to_droppable()?;
         Ok(())
     }
 

--- a/zkvm/tests/zkvm.rs
+++ b/zkvm/tests/zkvm.rs
@@ -506,7 +506,7 @@ fn taproot_program_path() {
 }
 
 #[test]
-fn programs_cannot_be_copied_or_dropped() {
+fn programs_cannot_be_copied() {
     let prog = Program::build(|p| {
         p.program(Program::build(|inner| {
             inner.verify();
@@ -518,22 +518,10 @@ fn programs_cannot_be_copied_or_dropped() {
         build_and_verify(prog, &vec![]),
         Err(VMError::TypeNotCopyable)
     );
-
-    let prog = Program::build(|p| {
-        p.program(Program::build(|inner| {
-            inner.verify();
-        })) // some arbitrary program
-        .drop();
-    });
-
-    assert_eq!(
-        build_and_verify(prog, &vec![]),
-        Err(VMError::TypeNotCopyable)
-    );
 }
 
 #[test]
-fn expressions_cannot_be_copied_or_dropped() {
+fn expressions_cannot_be_copied() {
     let prog = Program::build(|p| {
         p.mintime() // some arbitrary expression
             .dup(0);
@@ -543,37 +531,15 @@ fn expressions_cannot_be_copied_or_dropped() {
         build_and_verify(prog, &vec![]),
         Err(VMError::TypeNotCopyable)
     );
-
-    let prog = Program::build(|p| {
-        p.mintime() // some arbitrary expression
-            .drop();
-    });
-
-    assert_eq!(
-        build_and_verify(prog, &vec![]),
-        Err(VMError::TypeNotCopyable)
-    );
 }
 
 #[test]
-fn constraints_cannot_be_copied_or_dropped() {
+fn constraints_cannot_be_copied() {
     let prog = Program::build(|p| {
         p.mintime()
             .mintime()
             .eq() // some arbitrary constraint
             .dup(0);
-    });
-
-    assert_eq!(
-        build_and_verify(prog, &vec![]),
-        Err(VMError::TypeNotCopyable)
-    );
-
-    let prog = Program::build(|p| {
-        p.mintime()
-            .mintime()
-            .eq() // some arbitrary constraint
-            .drop();
     });
 
     assert_eq!(


### PR DESCRIPTION
Fixes https://github.com/stellar/slingshot/issues/406

The Program/Expression/Constraint are safe to drop types, but not safe to copy due to DoS risk. This was not implemented since we used a single category of "copyable types" for both copying and dropping. This patch introduces another category of "droppable types".

Specifically, Expression should be allowed to be dropped because of the `range` instruction that leaves it on stack. If one needs an inequality check, the left-on-stack expression must be dropped to clear the stack. In turn, `range` cannot consume the expression because then it cannot be used in downstream expressions, and we cannot allow copying for expressions for the DoS reasons.

Constraint and Program are also permitted to be dropped as there is no reason to prohibit that.