### PR TITLE
blockchain: witness hash for BlockTx and revamped state machine logic

### DIFF
--- a/blockchain/src/lib.rs
+++ b/blockchain/src/lib.rs
@@ -11,6 +11,7 @@ extern crate starsig;
 
 mod block;
 mod errors;
+mod mempool;
 mod protocol;
 mod shortid;
 mod state;
@@ -21,5 +22,6 @@ mod tests;
 
 pub use self::block::*;
 pub use self::errors::*;
+pub use self::mempool::*;
 pub use self::protocol::*;
 pub use self::state::*;

--- a/blockchain/src/mempool.rs
+++ b/blockchain/src/mempool.rs
@@ -3,7 +3,7 @@ use core::mem;
 use serde::{Deserialize, Serialize};
 
 use zkvm::bulletproofs::BulletproofGens;
-use zkvm::{ContractID, MerkleTree, TxEntry, TxID, TxLog, VerifiedTx};
+use zkvm::{ContractID, MerkleTree, Tx, TxEntry, TxID, TxLog, VerifiedTx};
 
 use super::block::{BlockHeader, BlockTx};
 use super::errors::BlockchainError;
@@ -40,6 +40,21 @@ impl MempoolEntry {
     /// Returns the block tx.
     pub fn block_tx(&self) -> &BlockTx {
         &self.block_tx
+    }
+
+    /// Returns the raw VM tx.
+    pub fn tx(&self) -> &Tx {
+        &self.block_tx.tx
+    }
+
+    /// Returns the verified transaction.
+    pub fn verified_tx(&self) -> &VerifiedTx {
+        &self.verified_tx
+    }
+
+    /// Returns the verified transaction.
+    pub fn utxo_proofs(&self) -> &[utreexo::Proof] {
+        &self.block_tx.proofs
     }
 }
 

--- a/blockchain/src/mempool.rs
+++ b/blockchain/src/mempool.rs
@@ -1,0 +1,193 @@
+//! Mempool
+use core::borrow::Borrow;
+use core::mem;
+use serde::{Deserialize, Serialize};
+
+use crate::utreexo::{self, utreexo_hasher, Catchup, WorkForest};
+use zkvm::{ContractID, Hasher, MerkleTree, TxEntry, TxHeader, TxLog, VerifiedTx};
+
+use super::block::BlockHeader;
+use super::errors::BlockchainError;
+use super::state::BlockchainState;
+
+/// Implements a pool of unconfirmed (not-in-the-block) transactions.
+#[derive(Clone, Serialize, Deserialize)]
+pub struct Mempool<T: MempoolItem> {
+    state: BlockchainState,
+    timestamp_ms: u64,
+    work_utreexo: utreexo::WorkForest,
+    items: Vec<T>,
+}
+
+/// Trait for the items in the mempool.
+pub trait MempoolItem {
+    /// Returns a reference to a verified transaction
+    fn verified_tx(&self) -> &VerifiedTx;
+
+    /// Returns a collection of Utreexo proofs for the transaction.
+    fn utreexo_proofs(&self) -> &[utreexo::Proof];
+}
+
+impl<T: MempoolItem> Mempool<T> {
+    /// Creates an empty mempool at a given state.
+    pub fn new(state: BlockchainState, timestamp_ms: u64) -> Self {
+        let work_utreexo = state.utreexo.work_forest();
+        Mempool {
+            state,
+            timestamp_ms,
+            work_utreexo,
+            items: Vec::new(),
+        }
+    }
+
+    /// Returns a list of transactions.
+    pub fn items(&self) -> impl Iterator<Item = &T> {
+        self.items.iter()
+    }
+
+    /// Returns the size of the mempool in number of transactions.
+    pub fn len(&self) -> usize {
+        self.items.len()
+    }
+
+    /// Updates timestamp and re-applies txs to filter out the outdated ones.
+    pub fn update_timestamp(&mut self, timestamp_ms: u64) {
+        self.timestamp_ms = timestamp_ms;
+        self.update_mempool();
+    }
+
+    /// Adds transaction to the mempool and verifies it.
+    pub fn append(&mut self, item: T) -> Result<(), BlockchainError> {
+        self.apply_item(&item)?;
+        self.items.push(item);
+        Ok(())
+    }
+
+    /// Creates a new block header and a new blockchain state using the current set of transactions.
+    /// Block header is accesible through the `tip` field on the new `BlockchainState` value.
+    pub fn make_block(&self) -> Result<(BlockchainState, Catchup), BlockchainError> {
+        let txroot = MerkleTree::root(
+            b"ZkVM.txroot",
+            self.items.iter().map(|tx| &tx.verified_tx().id),
+        );
+
+        let hasher = utreexo_hasher::<ContractID>();
+        let (new_forest, new_catchup) = self.work_utreexo.normalize(&hasher);
+        let utxoroot = new_forest.root(&hasher);
+
+        let new_header = BlockHeader {
+            version: self.state.tip.version,
+            height: self.state.tip.height + 1,
+            prev: self.state.tip.id(),
+            timestamp_ms: self.timestamp_ms,
+            txroot,
+            utxoroot,
+            ext: Vec::new(),
+        };
+
+        let new_state = BlockchainState {
+            tip: new_header,
+            utreexo: new_forest,
+        };
+
+        Ok((new_state, new_catchup))
+    }
+
+    fn update_mempool(&mut self) {
+        // reset the utreexo to the original state
+        self.work_utreexo = self.state.utreexo.work_forest();
+
+        // extract old
+        let old_items = mem::replace(&mut self.items, Vec::new());
+
+        for item in old_items.into_iter() {
+            match self.apply_item(&item) {
+                Ok(_) => {
+                    // still valid - put back to mempool
+                    self.items.push(item);
+                }
+                Err(_) => {
+                    // tx kicked out of the mempool
+                }
+            }
+        }
+    }
+
+    fn apply_item(&mut self, item: &T) -> Result<(), BlockchainError> {
+        let vtx = item.verified_tx();
+        let proofs = item.utreexo_proofs();
+
+        check_tx_header(&vtx.header, self.timestamp_ms, self.state.tip.version)?;
+
+        // Update block makes sure the that if half of tx fails, all changes are undone.
+        self.work_utreexo
+            .batch(|wf| apply_tx(wf, &vtx.log, proofs.iter(), &utreexo_hasher()))
+            .map(|_| ())
+    }
+}
+
+/// Applies transaction to the Utreexo forest
+fn apply_tx<P>(
+    work_forest: &mut WorkForest,
+    txlog: &TxLog,
+    utxo_proofs: impl IntoIterator<Item = P>,
+    hasher: &Hasher<ContractID>,
+) -> Result<(), BlockchainError>
+where
+    P: Borrow<utreexo::Proof>,
+{
+    let mut utxo_proofs = utxo_proofs.into_iter();
+
+    for entry in txlog.iter() {
+        match entry {
+            // Remove item from the UTXO set
+            TxEntry::Input(contract_id) => {
+                let proof = utxo_proofs
+                    .next()
+                    .ok_or(BlockchainError::UtreexoProofMissing)?;
+
+                work_forest
+                    .delete(contract_id, proof.borrow(), &hasher)
+                    .map_err(|e| BlockchainError::UtreexoError(e))?;
+            }
+            // Add item to the UTXO set
+            TxEntry::Output(contract) => {
+                work_forest.insert(&contract.id(), &hasher);
+            }
+            // Ignore all other log items
+            _ => {}
+        }
+    }
+
+    Ok(())
+}
+
+/// Checks the tx header for consistency with the block header.
+fn check_tx_header(
+    tx_header: &TxHeader,
+    timestamp_ms: u64,
+    block_version: u64,
+) -> Result<(), BlockchainError> {
+    check(
+        timestamp_ms >= tx_header.mintime_ms,
+        BlockchainError::BadTxTimestamp,
+    )?;
+    check(
+        timestamp_ms <= tx_header.maxtime_ms,
+        BlockchainError::BadTxTimestamp,
+    )?;
+    if block_version == 1 {
+        check(tx_header.version == 1, BlockchainError::BadTxVersion)?;
+    } else {
+        // future block versions permit higher tx versions
+    }
+    Ok(())
+}
+
+#[inline]
+fn check<E>(cond: bool, err: E) -> Result<(), E> {
+    if !cond {
+        return Err(err);
+    }
+    Ok(())
+}

--- a/blockchain/src/protocol.rs
+++ b/blockchain/src/protocol.rs
@@ -11,9 +11,9 @@ use starsig::{Signature, SigningKey, VerificationKey};
 use std::collections::HashMap;
 use std::time::{Duration, Instant};
 
-use super::block::{BlockHeader, BlockID};
+use super::block::{BlockHeader, BlockID, BlockTx};
+use super::mempool::Mempool;
 use super::shortid::{self, ShortID};
-use super::state::Mempool;
 use super::utreexo;
 use merlin::Transcript;
 use zkvm::Tx;
@@ -304,15 +304,6 @@ pub struct Block {
     header: BlockHeader,
     signature: Signature,
     txs: Vec<BlockTx>,
-}
-
-/// Transaction annotated with Utreexo proofs.
-#[derive(Clone, Serialize, Deserialize)]
-pub struct BlockTx {
-    /// Utreexo proofs.
-    pub proofs: Vec<utreexo::Proof>,
-    /// ZkVM transaction.
-    pub tx: Tx,
 }
 
 #[derive(Clone, Serialize, Deserialize)]

--- a/blockchain/src/tests.rs
+++ b/blockchain/src/tests.rs
@@ -81,6 +81,11 @@ fn test_state_machine() {
         utx.sign(sig)
     };
 
+    let block_tx = BlockTx {
+        tx: tx.clone(),
+        proofs: proofs.clone(),
+    };
+
     let vtx = tx.verify(&bp_gens).expect("Tx should be valid");
 
     let mut mempool = Mempool::new(state.clone(), 42);
@@ -92,13 +97,13 @@ fn test_state_machine() {
         })
         .expect("Tx must be valid");
 
-    let future_state = mempool
+    let (future_state, _catchup) = mempool
         .make_block()
         .expect("Block must be created successfully");
 
     // Apply the block to the state
-    let new_state = state
-        .apply_block(future_state.tip, &[vtx], proofs.iter())
+    let (new_state, _catchup, _vtxs) = state
+        .apply_block(future_state.tip, &[block_tx], &bp_gens)
         .expect("Block application should succeed.");
 
     let hasher = utreexo::utreexo_hasher::<ContractID>();

--- a/blockchain/src/tests.rs
+++ b/blockchain/src/tests.rs
@@ -6,7 +6,7 @@ use zkvm::bulletproofs::BulletproofGens;
 use super::*;
 use zkvm::{
     Anchor, Commitment, Contract, ContractID, Multisignature, PortableItem, Predicate, Program,
-    Prover, Signature, String, TxHeader, Value, VerificationKey, VerifiedTx,
+    Prover, Signature, String, TxHeader, Value, VerificationKey,
 };
 
 fn make_predicate(privkey: u64) -> Predicate {
@@ -28,21 +28,6 @@ fn make_nonce_contract(privkey: u64, qty: u64) -> Contract {
             flv: Commitment::unblinded(nonce_flavor()),
         })],
         anchor: Anchor::from_raw_bytes(anchor_bytes),
-    }
-}
-
-struct MempoolTx {
-    vtx: VerifiedTx,
-    proofs: Vec<utreexo::Proof>,
-}
-
-impl MempoolItem for MempoolTx {
-    fn verified_tx(&self) -> &VerifiedTx {
-        &self.vtx
-    }
-
-    fn utreexo_proofs(&self) -> &[utreexo::Proof] {
-        &self.proofs
     }
 }
 
@@ -86,15 +71,10 @@ fn test_state_machine() {
         proofs: proofs.clone(),
     };
 
-    let vtx = tx.verify(&bp_gens).expect("Tx should be valid");
-
     let mut mempool = Mempool::new(state.clone(), 42);
 
     mempool
-        .append(MempoolTx {
-            vtx: vtx.clone(),
-            proofs: proofs.clone(),
-        })
+        .append(block_tx.clone(), &bp_gens)
         .expect("Tx must be valid");
 
     let (future_state, _catchup) = mempool

--- a/demo/src/mempool.rs
+++ b/demo/src/mempool.rs
@@ -1,41 +1,13 @@
-use blockchain::utreexo;
-use blockchain::{self, MempoolItem};
-use zkvm::{Encodable, Tx, VerifiedTx};
-
-/// Mempool item
-pub struct MempoolTx {
-    pub tx: Tx,
-    pub verified_tx: VerifiedTx,
-    pub proofs: Vec<utreexo::Proof>,
-}
-
-impl MempoolItem for MempoolTx {
-    fn verified_tx(&self) -> &VerifiedTx {
-        &self.verified_tx
-    }
-
-    fn utreexo_proofs(&self) -> &[utreexo::Proof] {
-        &self.proofs
-    }
-}
+use blockchain::{self};
+use zkvm::Encodable;
 
 /// Our concrete instance of mempool
-pub type Mempool = blockchain::Mempool<MempoolTx>;
+pub type Mempool = blockchain::Mempool;
 
 // Estimated cost of a memory occupied by transactions in the mempool.
 pub fn estimated_memory_cost(mempool: &Mempool) -> usize {
-    let txbytes: usize = mempool.items().map(|item| item.tx.encoded_length()).sum();
-
-    let utxoproofsbytes: usize = mempool
-        .items()
-        .flat_map(|i| i.proofs.iter().map(|p| utreexo_proof_memory_cost(p)))
-        .sum();
-    txbytes + utxoproofsbytes
-}
-
-fn utreexo_proof_memory_cost(proof: &utreexo::Proof) -> usize {
-    match proof {
-        utreexo::Proof::Transient => 1,
-        utreexo::Proof::Committed(path) => 1 + path.encoded_length(),
-    }
+    mempool
+        .entries()
+        .map(|entry| entry.block_tx().encoded_length())
+        .sum()
 }

--- a/demo/templates/network/status.html.tera
+++ b/demo/templates/network/status.html.tera
@@ -22,15 +22,6 @@
   <div id="utreexo" style="height:400px;width:100%">
   </div>
 
-  <!--table class="table table-bordered block-header">
-    <tbody>
-      <tr>
-        <th>Catchup</th>
-        <td><pre><code>{{network_status.state.catchup | json_encode(pretty=true)}}</code></pre></td>
-      </tr>
-    </tbody>
-  </table-->
-
   <div class="d-flex justify-content-between flex-wrap flex-md-nowrap align-items-center pt-3 pb-2 mb-3">
     <h2 class="h2">Connections</h2>
   </div>

--- a/starsig/src/lib.rs
+++ b/starsig/src/lib.rs
@@ -17,6 +17,6 @@ mod tests;
 
 pub use self::batch::{BatchVerification, BatchVerifier, SingleVerifier};
 pub use self::errors::StarsigError;
-pub use self::key::{SigningKey,VerificationKey};
+pub use self::key::{SigningKey, VerificationKey};
 pub use self::signature::Signature;
 pub use self::transcript::TranscriptProtocol;

--- a/zkvm/docs/zkvm-blockchain.md
+++ b/zkvm/docs/zkvm-blockchain.md
@@ -82,6 +82,20 @@ T.append("ext", ext)
 blockid = T.challenge_bytes("id")
 ```
 
+## Transaction encoding
+
+TBD: describe transaction encoding.
+
+## Transaction witness hash
+
+Transaction witness hash commits to the raw transaction: the transaction header, utreexo proofs, tx program, signature and a constraint system proof.
+
+```
+T = Transcript("ZkVM.tx_witness_hash")
+T.append_message("tx", encoded_tx)
+result = T.challenge_bytes("hash")  // 32 bytes
+```
+
 ## Contract ID merkle leaf
 
 [Contract ID](zkvm-spec.md#contract-id) is hashed as a [merkle leaf hash](utreexo.md#merkle-root) for the Utreexo as follows:
@@ -329,11 +343,12 @@ Procedure:
 ## Compute txroot
 
 Input:
-- Ordered list `txids` of [transaction IDs](zkvm-spec.md#transaction-id).
+- Ordered list of block transactions.
 
 Output:
 - [Merkle root hash](zkvm-spec.md#merkle-binary-tree) of the transaction list.
 
 Procedure:
-1. Create a [transcript](zkvm-spec.md#transcript) `T` with label `transaction_ids`.
-2. Return `MerkleHash(T, txids)` using the label `txid` for each transaction ID in the list.
+1. Create a [transcript](zkvm-spec.md#transcript) `T` with label `ZkVM.txroot`.
+2. For each transaction, compute [witness hash](#transaction-witness-hash) `w`.
+3. Return `MerkleHash(T, {w})` hashing the witness hash with `T.append_message("txwit", w)`.

--- a/zkvm/src/encoding.rs
+++ b/zkvm/src/encoding.rs
@@ -7,6 +7,7 @@ use curve25519_dalek::scalar::Scalar;
 
 use crate::errors::VMError;
 
+/// API for reading from byte slices and advancing internal cursor.
 #[derive(Debug)]
 pub struct SliceReader<'a> {
     whole: &'a [u8],
@@ -23,10 +24,14 @@ impl<'a> SliceReader<'a> {
         }
     }
 
+    /// Remaining number of the unread bytes.
     pub fn len(&self) -> usize {
         self.end - self.start
     }
 
+    /// Wraps the reading logic in a block that checks that all bytes have been read.
+    /// If some are left unread, returns `Err(VMError::TrailingBytes)`.
+    /// Use method `skip_trailing_bytes` to ignore trailing bytes.
     pub fn parse<F, T>(data: &'a [u8], parse_fn: F) -> Result<T, VMError>
     where
         F: FnOnce(&mut Self) -> Result<T, VMError>,
@@ -39,6 +44,8 @@ impl<'a> SliceReader<'a> {
         Ok(result)
     }
 
+    /// Marks remaining unread bytes as read so that `parse` does not fail.
+    /// After calling this method, no more bytes can be read.
     pub fn skip_trailing_bytes(&mut self) -> usize {
         let trailing = self.end - self.start;
         self.start = self.end;
@@ -56,29 +63,33 @@ impl<'a> SliceReader<'a> {
         Ok(prefix)
     }
 
+    /// Reads a single byte.
     pub fn read_u8(&mut self) -> Result<u8, VMError> {
         let bytes = self.read_bytes(1)?;
         Ok(bytes[0])
     }
 
+    /// Reads a 4-byte LE32 integer.
     pub fn read_u32(&mut self) -> Result<u32, VMError> {
         let bytes = self.read_bytes(4)?;
         let x = LittleEndian::read_u32(&bytes);
         Ok(x)
     }
 
+    /// Reads an 8-byte LE64 integer.
     pub fn read_u64(&mut self) -> Result<u64, VMError> {
         let bytes = self.read_bytes(8)?;
         let x = LittleEndian::read_u64(&bytes);
         Ok(x)
     }
 
-    // returns a 32-byte "size" type used in ZkVM
+    /// Reads a 4-byte LE32 integer that's typically used as a length prefix.
     pub fn read_size(&mut self) -> Result<usize, VMError> {
         let n = self.read_u32()?;
         Ok(n as usize)
     }
 
+    /// Reads a 32-byte string (typically a hash).
     pub fn read_u8x32(&mut self) -> Result<[u8; 32], VMError> {
         let mut buf = [0u8; 32];
         let bytes = self.read_bytes(32)?;
@@ -86,6 +97,7 @@ impl<'a> SliceReader<'a> {
         Ok(buf)
     }
 
+    /// Reads a 64-byte string (typically a signature).
     pub fn read_u8x64(&mut self) -> Result<[u8; 64], VMError> {
         let mut buf = [0u8; 64];
         let bytes = self.read_bytes(64)?;
@@ -93,11 +105,13 @@ impl<'a> SliceReader<'a> {
         Ok(buf)
     }
 
+    /// Reads a compressed Ristretto255 point (32 bytes).
     pub fn read_point(&mut self) -> Result<CompressedRistretto, VMError> {
         let buf = self.read_u8x32()?;
         Ok(CompressedRistretto(buf))
     }
 
+    /// Reads a Ristretto255 scalar (32 bytes).
     pub fn read_scalar(&mut self) -> Result<Scalar, VMError> {
         let buf = self.read_u8x32()?;
         Scalar::from_canonical_bytes(buf).ok_or(VMError::FormatError)
@@ -107,37 +121,37 @@ impl<'a> SliceReader<'a> {
 // Writing API
 // This currently writes into the Vec, but later can be changed to support Arenas to minimize allocations
 
-// Writes a single byte
-pub(crate) fn write_u8<'a>(x: u8, target: &mut Vec<u8>) {
+/// Writes a single byte.
+pub fn write_u8<'a>(x: u8, target: &mut Vec<u8>) {
     target.push(x);
 }
 
-// Writes a LE32-encoded integer
-pub(crate) fn write_u32<'a>(x: u32, target: &mut Vec<u8>) {
+/// Writes a LE32-encoded integer.
+pub fn write_u32<'a>(x: u32, target: &mut Vec<u8>) {
     let mut buf = [0u8; 4];
     LittleEndian::write_u32(&mut buf, x);
     target.extend_from_slice(&buf);
 }
 
-// Writes a LE64-encoded integer
-pub(crate) fn write_u64<'a>(x: u64, target: &mut Vec<u8>) {
+/// Writes a LE64-encoded integer.
+pub fn write_u64<'a>(x: u64, target: &mut Vec<u8>) {
     let mut buf = [0u8; 8];
     LittleEndian::write_u64(&mut buf, x);
     target.extend_from_slice(&buf);
 }
 
-// Writes a usize as a LE32-encoded integer
-pub(crate) fn write_size<'a>(x: usize, target: &mut Vec<u8>) {
+/// Writes a usize as a LE32-encoded integer.
+pub fn write_size<'a>(x: usize, target: &mut Vec<u8>) {
     write_u32(x as u32, target);
 }
 
-/// Writes a 32-byte array and returns the subsequent slice
-pub(crate) fn write_bytes(x: &[u8], target: &mut Vec<u8>) {
+/// Writes a 32-byte array and returns the subsequent slice.
+pub fn write_bytes(x: &[u8], target: &mut Vec<u8>) {
     target.extend_from_slice(&x);
 }
 
 /// Writes a compressed point
-pub(crate) fn write_point(x: &CompressedRistretto, target: &mut Vec<u8>) {
+pub fn write_point(x: &CompressedRistretto, target: &mut Vec<u8>) {
     write_bytes(x.as_bytes(), target);
 }
 

--- a/zkvm/src/lib.rs
+++ b/zkvm/src/lib.rs
@@ -16,7 +16,7 @@ mod serialization;
 mod constraints;
 mod contract;
 mod debug;
-mod encoding;
+pub mod encoding;
 mod errors;
 mod fees;
 pub mod merkle;

--- a/zkvm/src/merkle.rs
+++ b/zkvm/src/merkle.rs
@@ -18,15 +18,6 @@ pub trait MerkleItem: Sized {
     fn commit(&self, t: &mut Transcript);
 }
 
-impl<T> MerkleItem for &T
-where
-    T: MerkleItem,
-{
-    fn commit(&self, t: &mut Transcript) {
-        T::commit(*self, t)
-    }
-}
-
 /// Precomputed hash instance.
 pub struct Hasher<M: MerkleItem> {
     t: Transcript,
@@ -143,6 +134,15 @@ impl<M: MerkleItem> MerkleRootBuilder<M> {
 impl MerkleItem for () {
     fn commit(&self, t: &mut Transcript) {
         t.append_message(b"", b"");
+    }
+}
+
+impl<T> MerkleItem for &T
+where
+    T: MerkleItem,
+{
+    fn commit(&self, t: &mut Transcript) {
+        T::commit(*self, t)
     }
 }
 

--- a/zkvm/src/tx.rs
+++ b/zkvm/src/tx.rs
@@ -21,7 +21,7 @@ use crate::verifier::Verifier;
 #[serde(transparent)]
 pub struct TxLog(Vec<TxEntry>);
 
-/// Transaction ID is a unique 32-byte identifier of a transaction.
+/// Transaction ID is a unique 32-byte identifier of a transaction effects represented by `TxLog`.
 #[derive(Copy, Clone, PartialEq, Debug, Serialize, Deserialize)]
 #[serde(transparent)]
 pub struct TxID(pub Hash);


### PR DESCRIPTION
This patch introduces a `BlockTx` type: that encapsulates `Tx` with its utxo proofs. The block header commits to that object, making all the proofs and signatures authenticated by the block header, eliminating DoS vector during block processing. Also the blockchain state and mempool are simplified.