### PR TITLE
utreexo: verify method

### DIFF
--- a/blockchain/src/utreexo/tests.rs
+++ b/blockchain/src/utreexo/tests.rs
@@ -146,6 +146,10 @@ fn transaction_success() {
     wf.delete(&Item(0), &proofs1[0], &hasher)
         .expect("Should not fail.");
 
+    forest1
+        .verify(&Item(1), &proofs1[1].as_path().unwrap(), &hasher)
+        .expect("Should not fail.");
+
     //  d
     //  |\
     //  a   b   c   new

--- a/zkvm/docs/zkvm-stubnet.md
+++ b/zkvm/docs/zkvm-stubnet.md
@@ -92,7 +92,7 @@ Periodically, every 60 seconds:
 When [`GetBlock`](#getblock) message is received,
 we reply immediately with the block requested using [`Block`](#block) message.
 
-When [`Blocks`](#blocks) message is received:
+When [`Block`](#block) message is received:
 1. If the block is a direct descendant: 
     1. It is verified and advances the state. 
     2. Orphan blocks from other peers are tried to be applied.

--- a/zkvm/src/tx.rs
+++ b/zkvm/src/tx.rs
@@ -268,6 +268,22 @@ impl TxLog {
     pub fn push(&mut self, item: TxEntry) {
         self.0.push(item);
     }
+
+    /// Iterator over the input entries
+    pub fn inputs(&self) -> impl Iterator<Item = &ContractID> {
+        self.0.iter().filter_map(|entry| match entry {
+            TxEntry::Input(contract_id) => Some(contract_id),
+            _ => None,
+        })
+    }
+
+    /// Iterator over the output entries
+    pub fn outputs(&self) -> impl Iterator<Item = &Contract> {
+        self.0.iter().filter_map(|entry| match entry {
+            TxEntry::Output(contract) => Some(contract),
+            _ => None,
+        })
+    }
 }
 
 impl From<Vec<TxEntry>> for TxLog {


### PR DESCRIPTION
This adds a non-mutating `Forest::verify` method so one can check the Utreexo proof faster than going through WorkForest. Ported from #400.
