### PR TITLE
p2p: change type of the custom message to binary buffer

### DIFF
--- a/demo/src/net.rs
+++ b/demo/src/net.rs
@@ -106,7 +106,7 @@ pub fn launch_p2p() -> P2PHandle {
                         println!("p2p: Peer disconnected: {}", pid)
                     }
                     NodeNotification::MessageReceived(pid, msg) => {
-                        println!("p2p: Received: `{}` from {}", msg, pid)
+                        println!("p2p: Received: `{:?}` from {}", msg, pid)
                     }
                     NodeNotification::InboundConnectionFailure(err) => {
                         println!("p2p: Inbound connection failure: {:?}", err)

--- a/p2p/examples/chatter.rs
+++ b/p2p/examples/chatter.rs
@@ -50,9 +50,11 @@ fn main() {
                             NodeNotification::PeerDisconnected(pid) => {
                                 println!("\n=> Peer disconnected: {}", pid)
                             }
-                            NodeNotification::MessageReceived(pid, msg) => {
-                                println!("\n=> Received: `{}` from {}", msg, pid)
-                            }
+                            NodeNotification::MessageReceived(pid, msg) => println!(
+                                "\n=> Received: `{}` from {}",
+                                String::from_utf8_lossy(&msg).into_owned(),
+                                pid
+                            ),
                             NodeNotification::InboundConnectionFailure(err) => {
                                 println!("\n=> Inbound connection failure: {:?}", err)
                             }
@@ -146,7 +148,7 @@ impl Console {
             }
             UserCommand::Broadcast(msg) => {
                 println!("=> Broadcasting: {:?}", &msg);
-                self.node.broadcast(msg).await;
+                self.node.broadcast(msg.as_bytes().to_vec()).await;
             }
             UserCommand::ListPeers => {
                 let peer_infos = self.node.list_peers().await;

--- a/p2p/src/node.rs
+++ b/p2p/src/node.rs
@@ -73,7 +73,7 @@ struct PeerState {
 pub enum NodeNotification {
     PeerAdded(PeerID),
     PeerDisconnected(PeerID),
-    MessageReceived(PeerID, String),
+    MessageReceived(PeerID, Vec<u8>),
     InboundConnectionFailure(cybershake::Error),
     OutboundConnectionFailure(cybershake::Error),
     /// Node has finished running.
@@ -93,7 +93,7 @@ pub struct PeerInfo {
 enum NodeMessage {
     ConnectPeer(net::TcpStream, Option<PeerID>),
     RemovePeer(PeerID),
-    Broadcast(String),
+    Broadcast(Vec<u8>),
     CountPeers(Reply<usize>),
     ListPeers(Reply<Vec<PeerInfo>>),
 }
@@ -209,7 +209,7 @@ impl NodeHandle {
     }
 
     /// Broadcasts a message to all peers.
-    pub async fn broadcast(&mut self, msg: String) {
+    pub async fn broadcast(&mut self, msg: Vec<u8>) {
         self.send_internal(NodeMessage::Broadcast(msg)).await
     }
 
@@ -433,7 +433,7 @@ impl Node {
             .count()
     }
 
-    async fn broadcast(&mut self, msg: String) {
+    async fn broadcast(&mut self, msg: Vec<u8>) {
         for (_id, peer_link) in self.peers.iter_mut() {
             peer_link.link.send(PeerMessage::Data(msg.clone())).await;
         }

--- a/p2p/src/peer.rs
+++ b/p2p/src/peer.rs
@@ -32,10 +32,11 @@ pub struct PeerAddr {
 pub enum PeerMessage {
     // Upon connection, a peer tells its listening port for dialing in, if it's available.
     Hello(u16),
-    // A plain message.
-    Data(String),
     // A list of known peers.
     Peers(Vec<PeerAddr>),
+    // An underlying message.
+    // TODO: change this to a Bytes buffer or generic type, to avoid unnecessary copying.
+    Data(Vec<u8>),
 }
 
 /// Interface for communication with the peer.


### PR DESCRIPTION
Later we should make it either a generic type encoded/decoded right by the p2p lib, or a Bytes buffer for avoiding unnecessary copies.