### PR TITLE
p2p: remove cybershake::Error

### DIFF
--- a/p2p/src/cybershake.rs
+++ b/p2p/src/cybershake.rs
@@ -113,7 +113,7 @@ pub enum Error {
 impl Error {
     pub fn new_io<E>(kind: io::ErrorKind, data: E) -> Self
     where
-        E: Into<Box<dyn std::error::Error + Send + Sync>>
+        E: Into<Box<dyn std::error::Error + Send + Sync>>,
     {
         Error::IoError(io::Error::new(kind, data))
     }
@@ -229,10 +229,16 @@ where
     // matching the blinded key they used for X3DH.
     let received_remote_id_blinded = received_remote_identity
         .blind(&remote_salt_and_id[0..SALT_LEN])
-        .ok_or(Error::new_io(io::ErrorKind::InvalidData, "Cannot blind key"))?;
+        .ok_or(Error::new_io(
+            io::ErrorKind::InvalidData,
+            "Cannot blind key",
+        ))?;
 
     if received_remote_id_blinded != remote_blinded_identity {
-        return Err(Error::new_io(io::ErrorKind::InvalidData, "Uncorrected blinded key."));
+        return Err(Error::new_io(
+            io::ErrorKind::InvalidData,
+            "Uncorrected blinded key.",
+        ));
     }
 
     Ok((received_remote_identity, outgoing, incoming))
@@ -354,7 +360,10 @@ impl<R: AsyncRead + Unpin> Incoming<R> {
         let n = LittleEndian::read_u32(&msglenprefix) as usize;
         // arbitrary 10Mb limit until we provide Tokio Codecs-based interface and push this decision to custom types.
         if n > 10_000_000 {
-            return Err(Error::new_io(io::ErrorKind::InvalidInput, format!("The size {} is bigger than allowed {}", n, 10_000_000)));
+            return Err(Error::new_io(
+                io::ErrorKind::InvalidInput,
+                format!("The size {} is bigger than allowed {}", n, 10_000_000),
+            ));
         }
         let mut buf = Vec::with_capacity(n);
         buf.resize(n, 0);
@@ -511,7 +520,10 @@ fn cybershake_x3dh(
             .chain(iter::once(&(eph1.as_scalar() * y))),
         iter::once(eph2.as_point().decompress()).chain(iter::once(id2.as_point().decompress())),
     )
-    .ok_or(Error::new_io(io::ErrorKind::InvalidData, "Cannot get shared secret."))?;
+    .ok_or(Error::new_io(
+        io::ErrorKind::InvalidData,
+        "Cannot get shared secret.",
+    ))?;
 
     t.append_message(b"x3dh", shared_secret.compress().as_bytes());
 

--- a/p2p/src/cybershake.rs
+++ b/p2p/src/cybershake.rs
@@ -212,12 +212,12 @@ where
     // matching the blinded key they used for X3DH.
     let received_remote_id_blinded = received_remote_identity
         .blind(&remote_salt_and_id[0..SALT_LEN])
-        .ok_or_else(|| {
+        .ok_or(
                 io::Error::new(
                     io::ErrorKind::InvalidData,
                     "Failed to decode Ristretto point",
                 )
-        })?;
+        )?;
 
     if received_remote_id_blinded != remote_blinded_identity {
         return Err(io::Error::new(

--- a/p2p/src/cybershake.rs
+++ b/p2p/src/cybershake.rs
@@ -149,9 +149,9 @@ where
     let remote_version = LittleEndian::read_u64(&remote_version_buf);
     if remote_version != ONLY_SUPPORTED_VERSION {
         return Err(io::Error::new(
-                io::ErrorKind::InvalidData,
-                "Incompatible cybershake version",
-            ));
+            io::ErrorKind::InvalidData,
+            "Incompatible cybershake version",
+        ));
     }
     let remote_blinded_identity = PublicKey::read_from(&mut reader).await?;
     let remote_ephemeral = PublicKey::read_from(&mut reader).await?;
@@ -212,18 +212,18 @@ where
     // matching the blinded key they used for X3DH.
     let received_remote_id_blinded = received_remote_identity
         .blind(&remote_salt_and_id[0..SALT_LEN])
-        .ok_or(
-                io::Error::new(
-                    io::ErrorKind::InvalidData,
-                    "Failed to decode Ristretto point",
-                )
-        )?;
+        .ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                "Failed to decode Ristretto point",
+            )
+        })?;
 
     if received_remote_id_blinded != remote_blinded_identity {
         return Err(io::Error::new(
-                io::ErrorKind::InvalidData,
-                "Remote identity key mismatch",
-            ));
+            io::ErrorKind::InvalidData,
+            "Remote identity key mismatch",
+        ));
     }
 
     Ok((received_remote_identity, outgoing, incoming))
@@ -345,11 +345,10 @@ impl<R: AsyncRead + Unpin> Incoming<R> {
         let n = LittleEndian::read_u32(&msglenprefix) as usize;
         // arbitrary 10Mb limit until we provide Tokio Codecs-based interface and push this decision to custom types.
         if n > 10_000_000 {
-            return Err(
-                io::Error::new(
-                    io::ErrorKind::InvalidData,
-                    "Message too big",
-                ));
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "Message too big",
+            ));
         }
         let mut buf = Vec::with_capacity(n);
         buf.resize(n, 0);

--- a/p2p/src/node.rs
+++ b/p2p/src/node.rs
@@ -337,7 +337,7 @@ impl Node {
         peer_addr: &PeerAddr,
     ) -> Result<(), cybershake::Error> {
         if peer_addr.addr.ip().is_unspecified() {
-            return Err(cybershake::Error::ProtocolError);
+            return Err(cybershake::Error::new_io(io::ErrorKind::AddrNotAvailable, peer_addr.addr.ip().to_string()));
         }
         // TODO: add short timeout to avoid hanging for too long waiting to be accepted.
         let stream = net::TcpStream::connect(&peer_addr.addr).await?;

--- a/p2p/src/node.rs
+++ b/p2p/src/node.rs
@@ -333,13 +333,13 @@ impl Node {
         Ok(())
     }
 
-    async fn connect_to_peer_addr(
-        &mut self,
-        peer_addr: &PeerAddr,
-    ) -> Result<(), io::Error> {
+    async fn connect_to_peer_addr(&mut self, peer_addr: &PeerAddr) -> Result<(), io::Error> {
         let ip = peer_addr.addr.ip();
         if ip.is_unspecified() {
-            return Err(io::Error::new(io::ErrorKind::Other, format!("{} is unspecified.", ip)));
+            return Err(io::Error::new(
+                io::ErrorKind::Other,
+                format!("{} is unspecified.", ip),
+            ));
         }
         // TODO: add short timeout to avoid hanging for too long waiting to be accepted.
         let stream = net::TcpStream::connect(&peer_addr.addr).await?;

--- a/p2p/src/node.rs
+++ b/p2p/src/node.rs
@@ -337,7 +337,10 @@ impl Node {
         peer_addr: &PeerAddr,
     ) -> Result<(), cybershake::Error> {
         if peer_addr.addr.ip().is_unspecified() {
-            return Err(cybershake::Error::new_io(io::ErrorKind::AddrNotAvailable, peer_addr.addr.ip().to_string()));
+            return Err(cybershake::Error::new_io(
+                io::ErrorKind::AddrNotAvailable,
+                peer_addr.addr.ip().to_string(),
+            ));
         }
         // TODO: add short timeout to avoid hanging for too long waiting to be accepted.
         let stream = net::TcpStream::connect(&peer_addr.addr).await?;

--- a/p2p/src/node.rs
+++ b/p2p/src/node.rs
@@ -337,8 +337,9 @@ impl Node {
         &mut self,
         peer_addr: &PeerAddr,
     ) -> Result<(), io::Error> {
-        if peer_addr.addr.ip().is_unspecified() {
-            return Err(io::Error::ProtocolError);
+        let ip = peer_addr.addr.ip();
+        if ip.is_unspecified() {
+            return Err(io::Error::new(io::ErrorKind::Other, format!("{} is unspecified.", ip)));
         }
         // TODO: add short timeout to avoid hanging for too long waiting to be accepted.
         let stream = net::TcpStream::connect(&peer_addr.addr).await?;

--- a/p2p/src/peer.rs
+++ b/p2p/src/peer.rs
@@ -96,7 +96,10 @@ impl PeerLink {
 
         if let Some(expected_pid) = expected_peer_id {
             if id != expected_pid {
-                return Err(cybershake::Error::new_io(io::ErrorKind::Other, "Remote and expected id do not match."));
+                return Err(cybershake::Error::new_io(
+                    io::ErrorKind::Other,
+                    "Remote and expected id do not match.",
+                ));
             }
         }
 
@@ -130,8 +133,12 @@ impl PeerLink {
                         }
                         PeerEvent::Receive(msg) => {
                             let msg = msg.map_err(Some)?;
-                            let msg = bincode::deserialize(&msg)
-                                .map_err(|_e| Some(cybershake::Error::new_io(io::ErrorKind::InvalidData, "Cannot deserialize message.")))?;
+                            let msg = bincode::deserialize(&msg).map_err(|_e| {
+                                Some(cybershake::Error::new_io(
+                                    io::ErrorKind::InvalidData,
+                                    "Cannot deserialize message.",
+                                ))
+                            })?;
 
                             notifications_channel
                                 .send(PeerNotification::Received(id.clone(), msg).into())

--- a/p2p/src/peer.rs
+++ b/p2p/src/peer.rs
@@ -96,7 +96,7 @@ impl PeerLink {
 
         if let Some(expected_pid) = expected_peer_id {
             if id != expected_pid {
-                return Err(cybershake::Error::ProtocolError);
+                return Err(cybershake::Error::new_io(io::ErrorKind::Other, "Remote and expected id do not match."));
             }
         }
 
@@ -131,7 +131,7 @@ impl PeerLink {
                         PeerEvent::Receive(msg) => {
                             let msg = msg.map_err(Some)?;
                             let msg = bincode::deserialize(&msg)
-                                .map_err(|_e| Some(cybershake::Error::ProtocolError))?;
+                                .map_err(|_e| Some(cybershake::Error::new_io(io::ErrorKind::InvalidData, "Cannot deserialize message.")))?;
 
                             notifications_channel
                                 .send(PeerNotification::Received(id.clone(), msg).into())

--- a/p2p/src/peer.rs
+++ b/p2p/src/peer.rs
@@ -96,7 +96,7 @@ impl PeerLink {
 
         if let Some(expected_pid) = expected_peer_id {
             if id != expected_pid {
-                return Err(cybershake::Error::new_io(
+                return Err(io::Error::new(
                     io::ErrorKind::Other,
                     "Remote and expected id do not match.",
                 ));
@@ -134,7 +134,7 @@ impl PeerLink {
                         PeerEvent::Receive(msg) => {
                             let msg = msg.map_err(Some)?;
                             let msg = bincode::deserialize(&msg).map_err(|_e| {
-                                Some(cybershake::Error::new_io(
+                                Some(io::Error::new(
                                     io::ErrorKind::InvalidData,
                                     "Cannot deserialize message.",
                                 ))


### PR DESCRIPTION
The `cybershake::Error` is mostly used where io::Error is needed, and so for a few places where we fail to decode a Ristretto point or the ciphertext is damaged we simply report `InvalidData`. After all, cybershake is an I/O middleware.