### PR TITLE
travis CI: do not check remote links as they are often broken

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ matrix:
   - language: ruby
     ruby: 2.3
     script:
-      - ruby check-markdown-links.rb
+      - DO_NOT_CHECK_HTTP_LINKS=1 ruby check-markdown-links.rb
   - language: go
     go: 1.11
     install: true


### PR DESCRIPTION
Some remote links don't load sometimes, causing very annoying CI failures. We can still check them manually from time to time, using the script, but that's causing more trouble in day-to-day development than reasonable.