### PR TITLE
zkvm: fix for r1cs update

### DIFF
--- a/zkvm/src/constraints.rs
+++ b/zkvm/src/constraints.rs
@@ -756,8 +756,13 @@ mod tests {
 
         fn constrain(&mut self, _lc: r1cs::LinearCombination) {}
 
-        fn multipliers_len(&self) -> usize {
-            self.num_multipliers
+        fn metrics(&self) -> r1cs::Metrics {
+            r1cs::Metrics {
+                multipliers: self.num_multipliers,
+                constraints: 0,
+                phase_one_constraints: 0,
+                phase_two_constraints: 0,
+            }
         }
     }
 }


### PR DESCRIPTION
A small fixup for the MockCS after we've made a breaking change to the R1CS metrics API: https://github.com/dalek-cryptography/bulletproofs/pull/322