### PR TITLE
readerwriter: simplify vector-reading API

### DIFF
--- a/demo/src/net.rs
+++ b/demo/src/net.rs
@@ -152,6 +152,6 @@ impl Encodable for Message {
 
 impl Decodable for Message {
     fn decode(buf: &mut impl Reader) -> Result<Self, ReadError> {
-        Ok(Self(buf.read_vec(buf.remaining_bytes()).unwrap()))
+        Ok(Self(buf.read_bytes(buf.remaining_bytes()).unwrap()))
     }
 }

--- a/p2p/examples/chatter.rs
+++ b/p2p/examples/chatter.rs
@@ -232,6 +232,6 @@ impl Encodable for Message {
 
 impl Decodable for Message {
     fn decode(buf: &mut impl Reader) -> Result<Self, ReadError> {
-        Ok(Self(buf.read_vec(buf.remaining_bytes()).unwrap()))
+        Ok(Self(buf.read_bytes(buf.remaining_bytes()).unwrap()))
     }
 }

--- a/p2p/src/codec.rs
+++ b/p2p/src/codec.rs
@@ -276,7 +276,7 @@ mod tests {
 
     impl Decodable for Message {
         fn decode(buf: &mut impl Reader) -> Result<Self, ReadError> {
-            Ok(Self(buf.read_vec(buf.remaining_bytes()).unwrap()))
+            Ok(Self(buf.read_bytes(buf.remaining_bytes()).unwrap()))
         }
     }
 

--- a/readerwriter/src/reader.rs
+++ b/readerwriter/src/reader.rs
@@ -103,7 +103,7 @@ pub trait Reader {
 
     /// Reads a vector of bytes with the required length.
     #[inline]
-    fn read_vec(&mut self, len: usize) -> Result<Vec<u8>, ReadError> {
+    fn read_bytes(&mut self, len: usize) -> Result<Vec<u8>, ReadError> {
         if self.remaining_bytes() < len {
             // this early check is to avoid allocating a vector
             // if we don't have enough data.
@@ -117,21 +117,18 @@ pub trait Reader {
 
     /// Reads a vector of items with the required count and a minimum item size.
     #[inline]
-    fn read_vec_with<T, E>(
+    fn read_vec<T, E>(
         &mut self,
         len: usize,
-        min_item_size: usize,
         closure: impl Fn(&mut Self) -> Result<T, E>,
     ) -> Result<Vec<T>, E>
     where
         E: From<ReadError>,
     {
-        if len > self.remaining_bytes() / min_item_size {
-            // this early check is to avoid allocating a vector
-            // if we don't have enough data.
+        if len > self.remaining_bytes() {
             return Err(ReadError::InsufficientBytes.into());
         }
-        let mut vec = Vec::with_capacity(len);
+        let mut vec = Vec::new();
         for _ in 0..len {
             vec.push(closure(self)?);
         }

--- a/zkvm/src/contract.rs
+++ b/zkvm/src/contract.rs
@@ -97,7 +97,7 @@ impl Contract {
         let anchor = Anchor(reader.read_u8x32()?);
         let predicate = Predicate::Opaque(reader.read_point()?);
         let k = reader.read_size()?;
-        let payload: Vec<PortableItem> = reader.read_vec_with(k, 5, |r| PortableItem::decode(r))?;
+        let payload: Vec<PortableItem> = reader.read_vec(k, |r| PortableItem::decode(r))?;
         Ok(Contract {
             anchor,
             predicate,
@@ -188,12 +188,12 @@ impl PortableItem {
         match output.read_u8()? {
             STRING_TYPE => {
                 let len = output.read_size()?;
-                let bytes = output.read_vec(len)?;
+                let bytes = output.read_bytes(len)?;
                 Ok(PortableItem::String(String::Opaque(bytes)))
             }
             PROG_TYPE => {
                 let len = output.read_size()?;
-                let bytes = output.read_vec(len)?;
+                let bytes = output.read_bytes(len)?;
                 Ok(PortableItem::Program(ProgramItem::Bytecode(bytes)))
             }
             VALUE_TYPE => {

--- a/zkvm/src/merkle.rs
+++ b/zkvm/src/merkle.rs
@@ -366,8 +366,8 @@ impl Path {
     /// than the 32-byte neighbour hashes.
     pub fn decode(reader: &mut impl Reader) -> Result<Self, VMError> {
         let position = reader.read_u64()?;
-        let neighbors_len = reader.read_u32()? as usize;
-        let neighbors = reader.read_vec_with(neighbors_len, 32, |r| r.read_u8x32().map(Hash))?;
+        let n = reader.read_u32()? as usize;
+        let neighbors = reader.read_vec(n, |r| r.read_u8x32().map(Hash))?;
         Ok(Path {
             position,
             neighbors,

--- a/zkvm/src/ops.rs
+++ b/zkvm/src/ops.rs
@@ -693,12 +693,12 @@ impl Instruction {
         match opcode {
             Opcode::Push => {
                 let strlen = program.read_size()?;
-                let data = program.read_vec(strlen)?;
+                let data = program.read_bytes(strlen)?;
                 Ok(Instruction::Push(String::Opaque(data)))
             }
             Opcode::Program => {
                 let strlen = program.read_size()?;
-                let data = program.read_vec(strlen)?;
+                let data = program.read_bytes(strlen)?;
                 Ok(Instruction::Program(ProgramItem::Bytecode(data)))
             }
             Opcode::Drop => Ok(Instruction::Drop),

--- a/zkvm/src/tx.rs
+++ b/zkvm/src/tx.rs
@@ -192,10 +192,10 @@ impl Tx {
     fn decode<'a>(r: &mut impl Reader) -> Result<Tx, VMError> {
         let header = TxHeader::decode(r)?;
         let prog_len = r.read_size()?;
-        let program = r.read_vec(prog_len)?;
+        let program = r.read_bytes(prog_len)?;
 
         let signature = Signature::from_bytes(r.read_u8x64()?).map_err(|_| VMError::FormatError)?;
-        let proof = R1CSProof::from_bytes(&r.read_vec(r.remaining_bytes())?)
+        let proof = R1CSProof::from_bytes(&r.read_bytes(r.remaining_bytes())?)
             .map_err(|_| VMError::FormatError)?;
         Ok(Tx {
             header,


### PR DESCRIPTION
1. Rename `read_vec` to `read_bytes`.
2. Rename `read_vec_with` to `read_vec`.
3. Remove min-item-length parameter and avoid pre-allocation of the vector to simplify the API.

closes #434