### PR TITLE
accounts: non-interactive payment addresses

### DIFF
--- a/accounts/Cargo.toml
+++ b/accounts/Cargo.toml
@@ -12,6 +12,7 @@ rand = "0.7"
 subtle = "2"
 curve25519-dalek = { version = "2", features = ["serde"] }
 serde = { version = "1.0", features=["derive"] }
+bech32 = "0.7"
 
 [dependencies.bulletproofs]
 git = "https://github.com/dalek-cryptography/bulletproofs"

--- a/accounts/src/address.rs
+++ b/accounts/src/address.rs
@@ -295,14 +295,18 @@ mod tests {
         assert_eq!(receiver.qty_blinding, enc_value.qty.witness().unwrap().1);
         assert_eq!(receiver.flv_blinding, enc_value.flv.witness().unwrap().1);
 
-        assert!(addr.decrypt(&enc_value, &data[0..72], &encr_scalar, rand::thread_rng()).is_none());
+        assert!(addr
+            .decrypt(&enc_value, &data[0..72], &encr_scalar, rand::thread_rng())
+            .is_none());
 
         // try flipping every bit and check that decryption fails.
         for i in 0..data.len() {
             for j in 0..8 {
                 let mut d = data.clone();
-                d[i] ^= 1<<j;
-                assert!(addr.decrypt(&enc_value, &d, &encr_scalar, rand::thread_rng()).is_none());
+                d[i] ^= 1 << j;
+                assert!(addr
+                    .decrypt(&enc_value, &d, &encr_scalar, rand::thread_rng())
+                    .is_none());
             }
         }
     }

--- a/accounts/src/address.rs
+++ b/accounts/src/address.rs
@@ -9,54 +9,94 @@
 //! Address consists of two 32-byte public keys (ristretto255 points): control key and encryption key.
 //! Encryption key is used to encrypt the payment amount and arbitrary additional data,
 //! while the control key allows spending the received funds.
+use core::iter;
 
 use rand::{CryptoRng, RngCore};
-use serde::{Serialize,Deserialize};
+use serde::{Deserialize, Serialize};
 
-use curve25519_dalek::ristretto::CompressedRistretto;
 use curve25519_dalek::constants::RISTRETTO_BASEPOINT_TABLE;
+use curve25519_dalek::ristretto::{CompressedRistretto, RistrettoPoint};
 use curve25519_dalek::scalar::Scalar;
-use curve25519_dalek::traits::VartimeMultiscalarMul;
+use curve25519_dalek::traits::{IsIdentity, VartimeMultiscalarMul};
 
 use merlin::Transcript;
-use keytree::{Xprv, Xpub};
-use zkvm::{Value,Commitment,ClearValue,TranscriptProtocol};
-use zkvm::encoding::Encodable;
 use zkvm::bulletproofs::PedersenGens;
-
+use zkvm::encoding::Encodable;
+use zkvm::{ClearValue, Commitment, TranscriptProtocol, Value};
 
 use super::Receiver;
 
+use bech32::{self, FromBase32, ToBase32};
+use std::fmt;
+
 /// Address to which funds can be sent
-#[derive(Clone,Debug,Serialize,Deserialize)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct Address {
+    label: String,
     control_key: CompressedRistretto,
     encryption_key: CompressedRistretto,
+    encryption_key_decompressed: RistrettoPoint,
 }
 
 impl Address {
-    pub fn from_xpub(xpub: &Xpub, seq: u64) -> Self {
-        unimplemented!()
+    /// Creates a new address with a label.
+    pub(crate) fn new(
+        label: String,
+        control_key: CompressedRistretto,
+        encryption_key: RistrettoPoint,
+    ) -> Self {
+        Self {
+            label,
+            control_key,
+            encryption_key: encryption_key.compress(),
+            encryption_key_decompressed: encryption_key,
+        }
+    }
+
+    /// Returns the label of this address.
+    pub fn label(&self) -> &str {
+        &self.label
+    }
+
+    /// Encodes address as bech32 string with the label as its prefix.
+    pub fn to_string(&self) -> String {
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(&self.control_key.as_bytes()[..]);
+        bytes.extend_from_slice(&self.encryption_key.as_bytes()[..]);
+        bech32::encode(&self.label, bytes.to_base32())
+            .expect("Label should be 1 to 83 characters long, printable ASCII, w/o mixing case.")
+    }
+
+    /// Attempts to decode the address from the string representation.
+    pub fn from_string(string: &str) -> Option<Self> {
+        let (label, data) = bech32::decode(&string).ok()?;
+        let buf = Vec::<u8>::from_base32(&data).ok()?;
+        if buf.len() != 64 {
+            return None;
+        }
+        let enckey = CompressedRistretto::from_slice(&buf[32..64]).decompress()?;
+        Some(Address {
+            label,
+            control_key: CompressedRistretto::from_slice(&buf[0..32]),
+            encryption_key: enckey.compress(),
+            encryption_key_decompressed: enckey,
+        })
     }
 
     /// Encrypts cleartext value as a zkvm Value with open commitments.
     /// Also returns the opaque data containing the ciphertext and nonce necessary for full decryption by the recipient.
     /// The opaque data must be embedded in a `data` entry in the txlog, in a random location in the transaction,
     /// in order to prevent evesdroppers from distinguishing send-to-address output from the change output.
-    pub fn encrypt<R: RngCore + CryptoRng>(&self, value: ClearValue, mut rng: R) -> Option<(Value, Vec<u8>)> {
+    pub fn encrypt<R: RngCore + CryptoRng>(
+        &self,
+        value: ClearValue,
+        mut rng: R,
+    ) -> (Value, Vec<u8>) {
         let nonce_scalar = Scalar::random(&mut rng);
         let nonce_point = (&nonce_scalar * &RISTRETTO_BASEPOINT_TABLE).compress();
-        let dh = (nonce_scalar * self.encryption_key.decompress()?).compress();
+        let dh = (nonce_scalar * self.encryption_key_decompressed).compress();
 
-        let mut t = Transcript::new(b"ZkVM.address.encrypt");
-        t.append_message(b"control_key", &self.control_key.as_bytes()[..]);
-        t.append_message(b"dh", &dh.as_bytes()[..]);
-        let qty_blinding = t.challenge_scalar(b"qty_blinding");
-        let flv_blinding = t.challenge_scalar(b"flv_blinding");
-        let mut flv_pad = [0u8; 32];
-        let mut qty_pad = [0u8; 8];
-        t.challenge_bytes(b"flv_pad", &mut flv_pad[..]);
-        t.challenge_bytes(b"qty_pad", &mut qty_pad[..]);
+        let (flv_blinding, qty_blinding, mut flv_pad, mut qty_pad) = self.derive_keys_from_dh(&dh);
 
         let encrypted_value = Value {
             qty: Commitment::blinded_with_factor(value.qty, qty_blinding),
@@ -65,30 +105,18 @@ impl Address {
 
         xor_slice(&mut flv_pad[..], &value.flv.as_bytes()[..]);
         xor_slice(&mut qty_pad[..], &value.qty.to_le_bytes()[..]);
-        
+
         let mut ciphertext = Vec::with_capacity(73);
 
-        // 32 bytes of nonce point
-        ciphertext.extend(&nonce_point.as_bytes()[..]);
-
-        // 32 bytes CT for the flavor
-        ciphertext.extend(&flv_pad[..]);
-        
-        //  8 bytes CT for the qty (u64-LE)
-        ciphertext.extend(&qty_pad[..]);
-
-        //  1 byte for the distinguisher
+        ciphertext.extend(&nonce_point.as_bytes()[..]); // 32 bytes of nonce point
+        ciphertext.extend(&flv_pad[..]); // 32 bytes CT for the flavor
+        ciphertext.extend(&qty_pad[..]); //  8 bytes CT for the qty (u64-LE)
         let tag = self.compute_distinguisher(&ciphertext[0..72], &encrypted_value);
-        ciphertext.push(tag);
+        ciphertext.push(tag); //  1 byte for the distinguisher
 
         assert!(ciphertext.len() == 73);
-        
-        Some(
-            (
-                encrypted_value,
-                ciphertext
-            )
-        )
+
+        (encrypted_value, ciphertext)
     }
 
     /// Attempts to decrypt the candidate data for the given Address and encrypted Value.
@@ -96,31 +124,29 @@ impl Address {
     /// or if it was malformed by the sender.
     /// This method fails fast if the data has incorrect length or an incorrect distinguisher byte,
     /// so you should feel free to call it on every data entry without any additional checks.
-    pub fn decrypt(&self, value: &Value, candidate_data: &[u8], decryption_key: &Scalar) -> Option<Receiver> {
+    pub fn decrypt<R: RngCore + CryptoRng>(
+        &self,
+        value: &Value,
+        candidate_data: &[u8],
+        decryption_key: &Scalar,
+        mut rng: R,
+    ) -> Option<Receiver> {
         if candidate_data.len() != 73 {
             return None;
         }
         let tag = candidate_data[72];
 
         if tag != self.compute_distinguisher(&candidate_data[0..72], value) {
-            // no const-time comparison used because we are comparing just one byte, and 
-            // the tag is not used for integrity check, but for quick rejection of irrelevant data entries.
+            // no const-time comparison used because we are comparing just one byte, and
+            // the tag is not used for integrity check, but only for quick rejection of irrelevant data entries.
             return None;
         }
         let ct = candidate_data;
         let nonce_point = CompressedRistretto::from_slice(&ct[0..32]).decompress()?;
-        
+
         let dh = (decryption_key * nonce_point).compress();
-        
-        let mut t = Transcript::new(b"ZkVM.address.encrypt");
-        t.append_message(b"control_key", &self.control_key.as_bytes()[..]);
-        t.append_message(b"dh", &dh.as_bytes()[..]);
-        let qty_blinding = t.challenge_scalar(b"qty_blinding");
-        let flv_blinding = t.challenge_scalar(b"flv_blinding");
-        let mut flv_pad = [0u8; 32];
-        let mut qty_pad = [0u8; 8];
-        t.challenge_bytes(b"flv_pad", &mut flv_pad[..]);
-        t.challenge_bytes(b"qty_pad", &mut qty_pad[..]);
+
+        let (flv_blinding, qty_blinding, mut flv_pad, mut qty_pad) = self.derive_keys_from_dh(&dh);
 
         xor_slice(&mut flv_pad[..], &ct[32..64]);
         xor_slice(&mut qty_pad[..], &ct[64..72]);
@@ -128,7 +154,7 @@ impl Address {
         let flv = Scalar::from_canonical_bytes(flv_pad)?;
         let qty = u64::from_le_bytes(qty_pad);
 
-        // need to verify: 
+        // need to verify:
         // 1) V.flv == flv*B + flv_blinding*B_blinding
         // 2) V.qty == qty*B + qty_blinding*B_blinding
         //
@@ -137,64 +163,147 @@ impl Address {
         //
         // Re-order:
         // identity == - V.flv - ch * V.qty + (flv + ch*qty)*B + (flv_bl + ch*qty_bl)*B_blinding
-        let mut rng = t.build_rng().finalize(&mut rand::thread_rng());
         let challenge = Scalar::random(&mut rng);
         let gens = PedersenGens::default();
 
         let p = RistrettoPoint::optional_multiscalar_mul(
-            [
-                -Scalar::one(),
-                -challenge,
-                flv + challenge * Scalar::from(qty),
-                flv_blinding + challenge * qty_blinding,
-            ].into_iter(),
-            [
-                value.flv.to_point().decompress(),
-                value.qty.to_point().decompress(),
-                Some(gens.B),
-                Some(gens.B_blinding)
-            ].into_iter(),
+            iter::once(-Scalar::one())
+                .chain(iter::once(-challenge))
+                .chain(iter::once(flv + challenge * Scalar::from(qty)))
+                .chain(iter::once(flv_blinding + challenge * qty_blinding)),
+            iter::once(value.flv.to_point().decompress())
+                .chain(iter::once(value.qty.to_point().decompress()))
+                .chain(iter::once(Some(gens.B.clone())))
+                .chain(iter::once(Some(gens.B_blinding.clone()))),
         )?;
 
         if !p.is_identity() {
             return None;
         }
-        
-        Receiver {
-            opaque_predicate: self.control_key,
-            value: ClearValue {
-                qty,
-                flv
-            }
-         qty_blinding: Scalar,
-        
-            /// Blinding factor for the flavor commitment.
-            pub flv_blinding: Scalar,
-        }
-        
-        // TODO: read flv scalar and qty u64, reconstruct pedersen commitment
-        // and compare with the value in multiscalar mul operation.
 
-        unimplemented!()
+        Some(Receiver {
+            opaque_predicate: self.control_key,
+            value: ClearValue { qty, flv },
+            qty_blinding,
+            flv_blinding,
+        })
     }
 
+    #[inline(always)]
+    fn derive_keys_from_dh(&self, dh: &CompressedRistretto) -> (Scalar, Scalar, [u8; 32], [u8; 8]) {
+        let mut t = Transcript::new(b"ZkVM.address.encrypt");
+        t.append_message(b"prefix", self.label.as_bytes());
+        t.append_message(b"control_key", &self.control_key.as_bytes()[..]);
+        t.append_message(b"dh", &dh.as_bytes()[..]);
+        let flv_blinding = t.challenge_scalar(b"flv_blinding");
+        let qty_blinding = t.challenge_scalar(b"qty_blinding");
+        let mut flv_pad = [0u8; 32];
+        let mut qty_pad = [0u8; 8];
+        t.challenge_bytes(b"flv_pad", &mut flv_pad[..]);
+        t.challenge_bytes(b"qty_pad", &mut qty_pad[..]);
+
+        (flv_blinding, qty_blinding, flv_pad, qty_pad)
+    }
 
     fn compute_distinguisher(&self, ct: &[u8], value: &Value) -> u8 {
         let mut t = Transcript::new(b"ZkVM.address.distinguisher");
         t.append_message(b"control_key", &self.control_key.as_bytes()[..]);
         t.append_message(b"encryption_key", &self.encryption_key.as_bytes()[..]);
-        value.encode(&mut t).expect("Encoding to Transcript never fails");
+        value
+            .encode(&mut t)
+            .expect("Encoding to Transcript never fails");
         t.append_message(b"ct", ct);
         let mut result = [0u8; 1];
         t.challenge_bytes(b"tag", &mut result[..]);
         result[0]
     }
+}
 
+impl fmt::Display for Address {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.to_string())
+    }
 }
 
 #[inline(always)]
 fn xor_slice(a: &mut [u8], b: &[u8]) {
     for i in 0..a.len() {
         a[i] = a[i] ^ b[i];
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+    use zkvm::VerificationKey;
+
+    #[test]
+    fn test_address_encoding() {
+        let label = "test".to_string();
+        let ctrl_scalar = Scalar::from(42u64);
+        let encr_scalar = Scalar::from(24u64);
+
+        let ctrl_key = VerificationKey::from_secret(&ctrl_scalar);
+        let encr_key = VerificationKey::from_secret(&encr_scalar);
+
+        let addr = Address::new(
+            label,
+            *ctrl_key.as_point(),
+            encr_key.as_point().decompress().unwrap(),
+        );
+        assert_eq!("test1uq90n36dnmdca0xpvr8we974x89adc54d70fzc4ca8k6yc8g9epca0ntey5jx9jk3q70cwzzjz6jgwx8zm6ezff4ss0f9a5p2junsnc480zqt", addr.to_string());
+        assert_eq!("test1uq90n36dnmdca0xpvr8we974x89adc54d70fzc4ca8k6yc8g9epca0ntey5jx9jk3q70cwzzjz6jgwx8zm6ezff4ss0f9a5p2junsnc480zqt", format!("{}", &addr));
+
+        assert_eq!(Some(addr.clone()), Address::from_string("test1uq90n36dnmdca0xpvr8we974x89adc54d70fzc4ca8k6yc8g9epca0ntey5jx9jk3q70cwzzjz6jgwx8zm6ezff4ss0f9a5p2junsnc480zqt"));
+        assert_eq!(None, Address::from_string("TEST1uq90n36dnmdca0xpvr8we974x89adc54d70fzc4ca8k6yc8g9epca0ntey5jx9jk3q70cwzzjz6jgwx8zm6ezff4ss0f9a5p2junsnc480zqt"));
+        assert_eq!(None, Address::from_string("best1uq90n36dnmdca0xpvr8we974x89adc54d70fzc4ca8k6yc8g9epca0ntey5jx9jk3q70cwzzjz6jgwx8zm6ezff4ss0f9a5p2junsnc480zqt"));
+        assert_eq!(None, Address::from_string("test1uq90n36dnmdca0xpvr8we974x89adc54d71fzc4ca8k6yc8g9epca0ntey5jx9jk3q70cwzzjz6jgwx8zm6ezff4ss0f9a5p2junsnc480zqt"));
+        assert_eq!(None, Address::from_string("test1uq90n36dnmdca0xpvr8we974x89adc54d71fzc4ca8k6yc8g9epca0ntey5jx9jk3q70cwzzjz6jgwx9zm6ezff4ss0f9a5p2junsnc480zqt"));
+    }
+
+    #[test]
+    fn test_encryption() {
+        let label = "test".to_string();
+        let ctrl_scalar = Scalar::from(42u64);
+        let encr_scalar = Scalar::from(24u64);
+
+        let ctrl_key = VerificationKey::from_secret(&ctrl_scalar);
+        let encr_key = VerificationKey::from_secret(&encr_scalar);
+
+        let addr = Address::new(
+            label,
+            *ctrl_key.as_point(),
+            encr_key.as_point().decompress().unwrap(),
+        );
+
+        let value = ClearValue {
+            flv: Scalar::zero(),
+            qty: 1000,
+        };
+
+        let (enc_value, data) = addr.encrypt(value, rand::thread_rng());
+
+        assert_eq!(data.len(), 73);
+
+        let receiver = addr
+            .decrypt(&enc_value, &data, &encr_scalar, rand::thread_rng())
+            .unwrap();
+
+        assert_eq!(&receiver.opaque_predicate, ctrl_key.as_point());
+        assert_eq!(receiver.value, value);
+        assert_eq!(receiver.qty_blinding, enc_value.qty.witness().unwrap().1);
+        assert_eq!(receiver.flv_blinding, enc_value.flv.witness().unwrap().1);
+
+        assert!(addr.decrypt(&enc_value, &data[0..72], &encr_scalar, rand::thread_rng()).is_none());
+
+        // try flipping every bit and check that decryption fails.
+        for i in 0..data.len() {
+            for j in 0..8 {
+                let mut d = data.clone();
+                d[i] ^= 1<<j;
+                assert!(addr.decrypt(&enc_value, &d, &encr_scalar, rand::thread_rng()).is_none());
+            }
+        }
     }
 }

--- a/accounts/src/address.rs
+++ b/accounts/src/address.rs
@@ -3,10 +3,198 @@
 //! Address is a 64-byte string that allows anyone to deliver payment w/o exchanging Receivers.
 //!
 //! Sending funds this way incurs a bit of overhead: extra `data` entry in the transaction,
-//! with 72 bytes of data.
+//! with 73 bytes of data. Last byte is used as a distinguisher to help identify the correct payload
+//! out of multiple w/o computational overhead in case of multiple send-to-address outputs.
 //!
 //! Address consists of two 32-byte public keys (ristretto255 points): control key and encryption key.
 //! Encryption key is used to encrypt the payment amount and arbitrary additional data,
 //! while the control key allows spending the received funds.
 
-// TBD.
+use rand::{CryptoRng, RngCore};
+use serde::{Serialize,Deserialize};
+
+use curve25519_dalek::ristretto::CompressedRistretto;
+use curve25519_dalek::constants::RISTRETTO_BASEPOINT_TABLE;
+use curve25519_dalek::scalar::Scalar;
+use curve25519_dalek::traits::VartimeMultiscalarMul;
+
+use merlin::Transcript;
+use keytree::{Xprv, Xpub};
+use zkvm::{Value,Commitment,ClearValue,TranscriptProtocol};
+use zkvm::encoding::Encodable;
+use zkvm::bulletproofs::PedersenGens;
+
+
+use super::Receiver;
+
+/// Address to which funds can be sent
+#[derive(Clone,Debug,Serialize,Deserialize)]
+pub struct Address {
+    control_key: CompressedRistretto,
+    encryption_key: CompressedRistretto,
+}
+
+impl Address {
+    pub fn from_xpub(xpub: &Xpub, seq: u64) -> Self {
+        unimplemented!()
+    }
+
+    /// Encrypts cleartext value as a zkvm Value with open commitments.
+    /// Also returns the opaque data containing the ciphertext and nonce necessary for full decryption by the recipient.
+    /// The opaque data must be embedded in a `data` entry in the txlog, in a random location in the transaction,
+    /// in order to prevent evesdroppers from distinguishing send-to-address output from the change output.
+    pub fn encrypt<R: RngCore + CryptoRng>(&self, value: ClearValue, mut rng: R) -> Option<(Value, Vec<u8>)> {
+        let nonce_scalar = Scalar::random(&mut rng);
+        let nonce_point = (&nonce_scalar * &RISTRETTO_BASEPOINT_TABLE).compress();
+        let dh = (nonce_scalar * self.encryption_key.decompress()?).compress();
+
+        let mut t = Transcript::new(b"ZkVM.address.encrypt");
+        t.append_message(b"control_key", &self.control_key.as_bytes()[..]);
+        t.append_message(b"dh", &dh.as_bytes()[..]);
+        let qty_blinding = t.challenge_scalar(b"qty_blinding");
+        let flv_blinding = t.challenge_scalar(b"flv_blinding");
+        let mut flv_pad = [0u8; 32];
+        let mut qty_pad = [0u8; 8];
+        t.challenge_bytes(b"flv_pad", &mut flv_pad[..]);
+        t.challenge_bytes(b"qty_pad", &mut qty_pad[..]);
+
+        let encrypted_value = Value {
+            qty: Commitment::blinded_with_factor(value.qty, qty_blinding),
+            flv: Commitment::blinded_with_factor(value.flv, flv_blinding),
+        };
+
+        xor_slice(&mut flv_pad[..], &value.flv.as_bytes()[..]);
+        xor_slice(&mut qty_pad[..], &value.qty.to_le_bytes()[..]);
+        
+        let mut ciphertext = Vec::with_capacity(73);
+
+        // 32 bytes of nonce point
+        ciphertext.extend(&nonce_point.as_bytes()[..]);
+
+        // 32 bytes CT for the flavor
+        ciphertext.extend(&flv_pad[..]);
+        
+        //  8 bytes CT for the qty (u64-LE)
+        ciphertext.extend(&qty_pad[..]);
+
+        //  1 byte for the distinguisher
+        let tag = self.compute_distinguisher(&ciphertext[0..72], &encrypted_value);
+        ciphertext.push(tag);
+
+        assert!(ciphertext.len() == 73);
+        
+        Some(
+            (
+                encrypted_value,
+                ciphertext
+            )
+        )
+    }
+
+    /// Attempts to decrypt the candidate data for the given Address and encrypted Value.
+    /// This can fail if the candidate data does not match the value (in which case another candidate should be tried),
+    /// or if it was malformed by the sender.
+    /// This method fails fast if the data has incorrect length or an incorrect distinguisher byte,
+    /// so you should feel free to call it on every data entry without any additional checks.
+    pub fn decrypt(&self, value: &Value, candidate_data: &[u8], decryption_key: &Scalar) -> Option<Receiver> {
+        if candidate_data.len() != 73 {
+            return None;
+        }
+        let tag = candidate_data[72];
+
+        if tag != self.compute_distinguisher(&candidate_data[0..72], value) {
+            // no const-time comparison used because we are comparing just one byte, and 
+            // the tag is not used for integrity check, but for quick rejection of irrelevant data entries.
+            return None;
+        }
+        let ct = candidate_data;
+        let nonce_point = CompressedRistretto::from_slice(&ct[0..32]).decompress()?;
+        
+        let dh = (decryption_key * nonce_point).compress();
+        
+        let mut t = Transcript::new(b"ZkVM.address.encrypt");
+        t.append_message(b"control_key", &self.control_key.as_bytes()[..]);
+        t.append_message(b"dh", &dh.as_bytes()[..]);
+        let qty_blinding = t.challenge_scalar(b"qty_blinding");
+        let flv_blinding = t.challenge_scalar(b"flv_blinding");
+        let mut flv_pad = [0u8; 32];
+        let mut qty_pad = [0u8; 8];
+        t.challenge_bytes(b"flv_pad", &mut flv_pad[..]);
+        t.challenge_bytes(b"qty_pad", &mut qty_pad[..]);
+
+        xor_slice(&mut flv_pad[..], &ct[32..64]);
+        xor_slice(&mut qty_pad[..], &ct[64..72]);
+
+        let flv = Scalar::from_canonical_bytes(flv_pad)?;
+        let qty = u64::from_le_bytes(qty_pad);
+
+        // need to verify: 
+        // 1) V.flv == flv*B + flv_blinding*B_blinding
+        // 2) V.qty == qty*B + qty_blinding*B_blinding
+        //
+        // Compress the statements with a random challenge:
+        // V.flv + ch * V.qty == (flv + ch*qty)*B + (flv_bl + ch*qty_bl)*B_blinding
+        //
+        // Re-order:
+        // identity == - V.flv - ch * V.qty + (flv + ch*qty)*B + (flv_bl + ch*qty_bl)*B_blinding
+        let mut rng = t.build_rng().finalize(&mut rand::thread_rng());
+        let challenge = Scalar::random(&mut rng);
+        let gens = PedersenGens::default();
+
+        let p = RistrettoPoint::optional_multiscalar_mul(
+            [
+                -Scalar::one(),
+                -challenge,
+                flv + challenge * Scalar::from(qty),
+                flv_blinding + challenge * qty_blinding,
+            ].into_iter(),
+            [
+                value.flv.to_point().decompress(),
+                value.qty.to_point().decompress(),
+                Some(gens.B),
+                Some(gens.B_blinding)
+            ].into_iter(),
+        )?;
+
+        if !p.is_identity() {
+            return None;
+        }
+        
+        Receiver {
+            opaque_predicate: self.control_key,
+            value: ClearValue {
+                qty,
+                flv
+            }
+         qty_blinding: Scalar,
+        
+            /// Blinding factor for the flavor commitment.
+            pub flv_blinding: Scalar,
+        }
+        
+        // TODO: read flv scalar and qty u64, reconstruct pedersen commitment
+        // and compare with the value in multiscalar mul operation.
+
+        unimplemented!()
+    }
+
+
+    fn compute_distinguisher(&self, ct: &[u8], value: &Value) -> u8 {
+        let mut t = Transcript::new(b"ZkVM.address.distinguisher");
+        t.append_message(b"control_key", &self.control_key.as_bytes()[..]);
+        t.append_message(b"encryption_key", &self.encryption_key.as_bytes()[..]);
+        value.encode(&mut t).expect("Encoding to Transcript never fails");
+        t.append_message(b"ct", ct);
+        let mut result = [0u8; 1];
+        t.challenge_bytes(b"tag", &mut result[..]);
+        result[0]
+    }
+
+}
+
+#[inline(always)]
+fn xor_slice(a: &mut [u8], b: &[u8]) {
+    for i in 0..a.len() {
+        a[i] = a[i] ^ b[i];
+    }
+}

--- a/accounts/src/lib.rs
+++ b/accounts/src/lib.rs
@@ -69,6 +69,6 @@ mod receiver;
 #[cfg(test)]
 mod tests;
 
-pub use derivation::{XprvDerivation, XpubDerivation};
 pub use address::Address;
+pub use derivation::{XprvDerivation, XpubDerivation};
 pub use receiver::{Receiver, ReceiverID, ReceiverReply, ReceiverWitness};

--- a/accounts/src/lib.rs
+++ b/accounts/src/lib.rs
@@ -70,4 +70,5 @@ mod receiver;
 mod tests;
 
 pub use derivation::{XprvDerivation, XpubDerivation};
+pub use address::Address;
 pub use receiver::{Receiver, ReceiverID, ReceiverReply, ReceiverWitness};

--- a/zkvm/src/contract.rs
+++ b/zkvm/src/contract.rs
@@ -170,8 +170,7 @@ impl Encodable for PortableItem {
             // Value = 0x02 || <32 bytes> || <32 bytes>
             PortableItem::Value(v) => {
                 w.write_u8(b"type", VALUE_TYPE)?;
-                w.write_point(b"qty", &v.qty.to_point())?;
-                w.write_point(b"flv", &v.flv.to_point())?;
+                v.encode(w)?;
             }
         }
         Ok(())

--- a/zkvm/src/types.rs
+++ b/zkvm/src/types.rs
@@ -110,7 +110,7 @@ pub struct Value {
 /// Represents a cleartext value of an issued asset in the VM.
 /// This is not the same as `spacesuit::Value` since it is guaranteed to be in-range
 /// (negative quantity is not representable with this type).
-#[derive(Copy, Clone, Debug, Serialize, Deserialize)]
+#[derive(Copy, Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct ClearValue {
     /// Cleartext quantity integer
     pub qty: u64,

--- a/zkvm/src/types.rs
+++ b/zkvm/src/types.rs
@@ -352,6 +352,19 @@ impl Value {
     }
 }
 
+impl Encodable for Value {
+    fn encode(&self, w: &mut impl Writer) -> Result<(), WriteError> {
+        w.write_point(b"qty", &self.qty.to_point())?;
+        w.write_point(b"flv", &self.flv.to_point())?;
+        Ok(())
+    }
+}
+impl ExactSizeEncodable for Value {
+    fn encoded_size(&self) -> usize {
+        64
+    }
+}
+
 impl ClearValue {
     /// Selects a subset of coins to be equal or greater than the given value.
     /// Returns the list of selected values and an amount of _change_ quantity.


### PR DESCRIPTION
This introduces an **address API**: ability to create a short and friendly one-time-use string to receive money in encrypted form:

```
test1uq90n36dnmdca0xpvr8we974x89adc54d70fzc4ca8k6yc8g9epca0ntey5jx9jk3q70cwzzjz6jgwx8zm6ezff4ss0f9a5p2junsnc480zqt
```

### Technical specs

* String format uses [bech32](https://github.com/bitcoin/bips/blob/master/bip-0173.mediawiki).
* Prefix of the string (`test` in the example above) is customizable: it can be _versioned_ and also separates addresses between the networks/ledgers.
* The address contains two pubkeys: one for the predicate, another for encryption. Both are derived from the account Xpub in a way that allows user to decrypt incoming payments with just Xpub, without having access to the private key of the predicate.
* Sender embeds a 73-byte ciphertext string in a `data` entry in the transaction, located randomly in the txlog, so the payment output cannot be distinguished from the change output.
* Recipient detects the desired output by the address, scans all data entries and tries to decrypt each of them. Data entries have a short 1-byte distinguisher tag that helps failing quickly and avoid performing expensive part of the decryption for unrelated entries. This is especially useful if the transaction pays to multiple addresses at the same time.

Closes #470.