### PR TITLE
node/wallet: new module for handling accounts and spendable utxos

### DIFF
--- a/accounts/Cargo.toml
+++ b/accounts/Cargo.toml
@@ -14,11 +14,6 @@ curve25519-dalek = { version = "2", features = ["serde"] }
 serde = { version = "1.0", features=["derive"] }
 bech32 = "0.7"
 
-[dependencies.bulletproofs]
-git = "https://github.com/dalek-cryptography/bulletproofs"
-branch = "develop"
-features = ["yoloproofs"]
-
 [dependencies.keytree]
 path = "../keytree"
 

--- a/accounts/src/address.rs
+++ b/accounts/src/address.rs
@@ -22,7 +22,7 @@ use curve25519_dalek::traits::{IsIdentity, VartimeMultiscalarMul};
 use merlin::Transcript;
 use zkvm::bulletproofs::PedersenGens;
 use zkvm::encoding::Encodable;
-use zkvm::{Predicate, ClearValue, Commitment, TranscriptProtocol, Value};
+use zkvm::{ClearValue, Commitment, Predicate, TranscriptProtocol, Value};
 
 use super::Receiver;
 

--- a/accounts/src/address.rs
+++ b/accounts/src/address.rs
@@ -58,6 +58,11 @@ impl Address {
         &self.label
     }
 
+    /// Returns the control key
+    pub fn control_key(&self) -> &CompressedRistretto {
+        &self.control_key
+    }
+
     /// Encodes address as bech32 string with the label as its prefix.
     pub fn to_string(&self) -> String {
         let mut bytes = Vec::new();

--- a/accounts/src/derivation.rs
+++ b/accounts/src/derivation.rs
@@ -5,8 +5,7 @@ use merlin::Transcript;
 use musig::VerificationKey;
 use zkvm::{ClearValue, TranscriptProtocol};
 
-use super::Address;
-use super::{Receiver, ReceiverWitness};
+use super::{Address, Receiver};
 
 /// Sequence number for derivation
 pub type Sequence = u64;
@@ -65,7 +64,7 @@ impl XpubDerivation for Xpub {
                 ctrl_key.into_point(),
                 &enc_key * &RISTRETTO_BASEPOINT_TABLE,
             ),
-            enc_key
+            enc_key,
         )
     }
 

--- a/accounts/src/derivation.rs
+++ b/accounts/src/derivation.rs
@@ -8,14 +8,17 @@ use zkvm::{ClearValue, TranscriptProtocol};
 use super::Address;
 use super::{Receiver, ReceiverWitness};
 
+/// Sequence number for derivation
+pub type Sequence = u64;
+
 /// Extension trait for Xprv to derive keys based on sequence number.
 pub trait XprvDerivation {
     /// Derives a key for a given sequence number.
-    fn key_at_sequence(&self, sequence: u64) -> Scalar;
+    fn key_at_sequence(&self, sequence: Sequence) -> Scalar;
 }
 
 impl XprvDerivation for Xprv {
-    fn key_at_sequence(&self, sequence: u64) -> Scalar {
+    fn key_at_sequence(&self, sequence: Sequence) -> Scalar {
         self.derive_key(|t| t.append_u64(b"sequence", sequence))
     }
 }
@@ -23,28 +26,28 @@ impl XprvDerivation for Xprv {
 /// Extension trait for Xprv to derive keys based on sequence number.
 pub trait XpubDerivation {
     /// Derives a key for a given sequence number.
-    fn key_at_sequence(&self, sequence: u64) -> VerificationKey;
+    fn key_at_sequence(&self, sequence: Sequence) -> VerificationKey;
 
     /// Derives an Address for a given sequence number.
-    fn address_at_sequence(&self, label: String, sequence: u64) -> Address;
+    fn address_at_sequence(&self, label: String, sequence: Sequence) -> (Address, Scalar);
 
     /// Creates a new receiver for the given sequence number and value
-    fn receiver_at_sequence(&self, sequence: u64, value: ClearValue) -> ReceiverWitness;
+    fn receiver_at_sequence(&self, sequence: Sequence, value: ClearValue) -> Receiver;
 
     /// Derives blinding factors for the given value and sequence number.
     /// Q: Why deterministic derivation?
     /// A: Blinding factors are high-entropy, so loss of such data is fatal.
     ///    While loss of low-entropy metadata such as qty and flavor is recoverable
     ///    from multiple other systems (analytics, counter-parties), or even by bruteforce search.
-    fn value_blinding_factors(&self, sequence: u64, value: &ClearValue) -> (Scalar, Scalar);
+    fn value_blinding_factors(&self, sequence: Sequence, value: &ClearValue) -> (Scalar, Scalar);
 }
 
 impl XpubDerivation for Xpub {
-    fn key_at_sequence(&self, sequence: u64) -> VerificationKey {
+    fn key_at_sequence(&self, sequence: Sequence) -> VerificationKey {
         self.derive_key(|t| t.append_u64(b"sequence", sequence))
     }
 
-    fn address_at_sequence(&self, label: String, sequence: u64) -> Address {
+    fn address_at_sequence(&self, label: String, sequence: Sequence) -> (Address, Scalar) {
         let ctrl_key = self.key_at_sequence(sequence);
         // Note: we derive encryption privkey from the xpub public key, effectively binding it
         // to the secrecy of only the derivation key of xpub.
@@ -56,29 +59,29 @@ impl XpubDerivation for Xpub {
         t.append_u64(b"sequence", sequence);
         let enc_key = t.challenge_scalar(b"key");
 
-        Address::new(
-            label,
-            ctrl_key.into_point(),
-            &enc_key * &RISTRETTO_BASEPOINT_TABLE,
+        (
+            Address::new(
+                label,
+                ctrl_key.into_point(),
+                &enc_key * &RISTRETTO_BASEPOINT_TABLE,
+            ),
+            enc_key
         )
     }
 
-    fn receiver_at_sequence(&self, sequence: u64, value: ClearValue) -> ReceiverWitness {
+    fn receiver_at_sequence(&self, sequence: Sequence, value: ClearValue) -> Receiver {
         let key = self.key_at_sequence(sequence);
         let (qty_blinding, flv_blinding) = self.value_blinding_factors(sequence, &value);
 
-        ReceiverWitness {
-            sequence,
-            receiver: Receiver {
-                opaque_predicate: key.into_point(),
-                value,
-                qty_blinding,
-                flv_blinding,
-            },
+        Receiver {
+            opaque_predicate: key.into_point(),
+            value,
+            qty_blinding,
+            flv_blinding,
         }
     }
 
-    fn value_blinding_factors(&self, sequence: u64, value: &ClearValue) -> (Scalar, Scalar) {
+    fn value_blinding_factors(&self, sequence: Sequence, value: &ClearValue) -> (Scalar, Scalar) {
         // Blinding factors are deterministically derived in order to avoid
         // having to backup secret material.
         // It can be always re-created from the single root xpub.

--- a/accounts/src/lib.rs
+++ b/accounts/src/lib.rs
@@ -70,5 +70,5 @@ mod receiver;
 mod tests;
 
 pub use address::Address;
-pub use derivation::{XprvDerivation, XpubDerivation};
+pub use derivation::{XprvDerivation, XpubDerivation, Sequence};
 pub use receiver::{Receiver, ReceiverID, ReceiverReply, ReceiverWitness};

--- a/accounts/src/lib.rs
+++ b/accounts/src/lib.rs
@@ -70,5 +70,5 @@ mod receiver;
 mod tests;
 
 pub use address::Address;
-pub use derivation::{XprvDerivation, XpubDerivation, Sequence};
+pub use derivation::{Sequence, XprvDerivation, XpubDerivation};
 pub use receiver::{Receiver, ReceiverID, ReceiverReply, ReceiverWitness};

--- a/accounts/src/receiver.rs
+++ b/accounts/src/receiver.rs
@@ -6,14 +6,14 @@ use musig::VerificationKey;
 use serde::{Deserialize, Serialize};
 use zkvm::{Anchor, ClearValue, Commitment, Contract, PortableItem, Predicate, Value};
 
-use crate::{XpubDerivation,Sequence};
+use crate::{Sequence, XpubDerivation};
 
 #[derive(Copy, Clone, Eq, Hash, Debug, PartialEq, Default, Serialize, Deserialize)]
 #[serde(transparent)]
 pub struct ReceiverID([u8; 32]);
 
 /// Receiver describes the destination for the payment.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Copy, Clone, Debug, Serialize, Deserialize)]
 pub struct Receiver {
     /// Address to which the payment must be sent.
     pub opaque_predicate: CompressedRistretto,
@@ -30,7 +30,7 @@ pub struct Receiver {
 
 /// Private annotation to the receiver that describes derivation path
 /// DEPRECATED?
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Copy, Clone, Debug, Serialize, Deserialize)]
 pub struct ReceiverWitness {
     /// Account's sequence number at which this receiver was generated.
     pub sequence: Sequence,

--- a/accounts/src/receiver.rs
+++ b/accounts/src/receiver.rs
@@ -6,7 +6,7 @@ use musig::VerificationKey;
 use serde::{Deserialize, Serialize};
 use zkvm::{Anchor, ClearValue, Commitment, Contract, PortableItem, Predicate, Value};
 
-use crate::XpubDerivation;
+use crate::{XpubDerivation,Sequence};
 
 #[derive(Copy, Clone, Eq, Hash, Debug, PartialEq, Default, Serialize, Deserialize)]
 #[serde(transparent)]
@@ -29,10 +29,11 @@ pub struct Receiver {
 }
 
 /// Private annotation to the receiver that describes derivation path
+/// DEPRECATED?
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct ReceiverWitness {
     /// Account's sequence number at which this receiver was generated.
-    pub sequence: u64,
+    pub sequence: Sequence,
 
     /// Receiver that can be shared with the payer.
     pub receiver: Receiver,
@@ -50,8 +51,11 @@ pub struct ReceiverReply {
 
 impl ReceiverWitness {
     /// Creates a new receiver for the Xpub, sequence number and a value
-    pub fn new(xpub: &Xpub, sequence: u64, value: ClearValue) -> ReceiverWitness {
-        xpub.receiver_at_sequence(sequence, value)
+    pub fn new(xpub: &Xpub, sequence: Sequence, value: ClearValue) -> ReceiverWitness {
+        ReceiverWitness {
+            sequence,
+            receiver: xpub.receiver_at_sequence(sequence, value),
+        }
     }
 
     /// Returns `Predicate::Key`
@@ -100,6 +104,12 @@ impl Receiver {
             qty: Commitment::blinded_with_factor(self.value.qty, self.qty_blinding),
             flv: Commitment::blinded_with_factor(self.value.flv, self.flv_blinding),
         }
+    }
+
+    /// Verifies that the value is encrypted with blinding factors of the receiver.
+    pub fn verify_value(&self, value: &Value) -> bool {
+        // TBD: make a Commitment::verify_batch function to check multiple commitments at once.
+        value == &self.blinded_value()
     }
 
     /// Creates a new contract for the given receiver and an anchor.

--- a/accounts/src/receiver.rs
+++ b/accounts/src/receiver.rs
@@ -51,18 +51,7 @@ pub struct ReceiverReply {
 impl ReceiverWitness {
     /// Creates a new receiver for the Xpub, sequence number and a value
     pub fn new(xpub: &Xpub, sequence: u64, value: ClearValue) -> ReceiverWitness {
-        let key = xpub.key_at_sequence(sequence);
-        let (qty_blinding, flv_blinding) = xpub.value_blinding_factors(sequence, &value);
-
-        ReceiverWitness {
-            sequence,
-            receiver: Receiver {
-                opaque_predicate: key.into_point(),
-                value,
-                qty_blinding,
-                flv_blinding,
-            },
-        }
+        xpub.receiver_at_sequence(sequence, value)
     }
 
     /// Returns `Predicate::Key`

--- a/accounts/src/tests.rs
+++ b/accounts/src/tests.rs
@@ -378,7 +378,10 @@ impl Wallet {
     fn generate_receiver(&mut self, value: ClearValue) -> ReceiverWitness {
         let seq = self.sequence;
         self.sequence += 1;
-        self.xprv.as_xpub().receiver_at_sequence(seq, value)
+        ReceiverWitness {
+            sequence: seq,
+            receiver: self.xprv.as_xpub().receiver_at_sequence(seq, value)
+        }
     }
 }
 

--- a/accounts/src/tests.rs
+++ b/accounts/src/tests.rs
@@ -2,12 +2,12 @@ use merlin::Transcript;
 use rand::SeedableRng;
 use rand_chacha::ChaChaRng;
 
-use bulletproofs::BulletproofGens;
 use curve25519_dalek::scalar::Scalar;
 use keytree::Xprv;
 use musig::{Multisignature, Signature};
 
 use blockchain::{utreexo, BlockHeader, BlockTx, BlockchainState, Mempool};
+use zkvm::bulletproofs::BulletproofGens;
 use zkvm::{Anchor, ClearValue, Contract, ContractID, Program, Prover, TxEntry, TxHeader};
 
 use crate::{ReceiverReply, ReceiverWitness, XprvDerivation};

--- a/accounts/src/tests.rs
+++ b/accounts/src/tests.rs
@@ -10,7 +10,7 @@ use blockchain::{utreexo, BlockHeader, BlockTx, BlockchainState, Mempool};
 use zkvm::bulletproofs::BulletproofGens;
 use zkvm::{Anchor, ClearValue, Contract, ContractID, Program, Prover, TxEntry, TxHeader};
 
-use crate::{ReceiverReply, ReceiverWitness, XprvDerivation};
+use crate::{ReceiverReply, ReceiverWitness, XprvDerivation, XpubDerivation};
 
 /// The complete state of the user node: their wallet and their blockchain state.
 #[derive(Clone)]
@@ -378,7 +378,7 @@ impl Wallet {
     fn generate_receiver(&mut self, value: ClearValue) -> ReceiverWitness {
         let seq = self.sequence;
         self.sequence += 1;
-        ReceiverWitness::new(self.xprv.as_xpub(), seq, value)
+        self.xprv.as_xpub().receiver_at_sequence(seq, value)
     }
 }
 

--- a/accounts/src/tests.rs
+++ b/accounts/src/tests.rs
@@ -380,7 +380,7 @@ impl Wallet {
         self.sequence += 1;
         ReceiverWitness {
             sequence: seq,
-            receiver: self.xprv.as_xpub().receiver_at_sequence(seq, value)
+            receiver: self.xprv.as_xpub().receiver_at_sequence(seq, value),
         }
     }
 }

--- a/blockchain/src/tests.rs
+++ b/blockchain/src/tests.rs
@@ -2,7 +2,6 @@ use curve25519_dalek::scalar::Scalar;
 use merlin::Transcript;
 use rand::RngCore;
 use zkvm::bulletproofs::BulletproofGens;
-use zkvm::VerifiedTx;
 
 use super::*;
 use zkvm::{
@@ -112,12 +111,14 @@ fn test_state_machine() {
         .append(block_tx.clone(), &bp_gens)
         .expect("Tx must be valid");
 
-    let (future_state, _catchup) = mempool.make_block();
+    let verified_block = mempool.make_block();
+    let future_state = verified_block.blockchain_state();
 
     // Apply the block to the state
-    let (new_state, _catchup, _vtxs) = state
+    let applied_block = state
         .apply_block(future_state.tip, &[block_tx], &bp_gens)
         .expect("Block application should succeed.");
+    let new_state = applied_block.blockchain_state();
 
     let hasher = utreexo::utreexo_hasher::<ContractID>();
     assert_eq!(
@@ -128,6 +129,7 @@ fn test_state_machine() {
 
 #[test]
 fn test_p2p_protocol() {
+    use super::block::*;
     use super::protocol::*;
     use async_trait::async_trait;
     use futures_executor::block_on;
@@ -219,17 +221,15 @@ fn test_p2p_protocol() {
         }
 
         /// Stores the new block and an updated state.
-        fn store_block(
-            &mut self,
-            block: Block,
-            new_state: BlockchainState,
-            _catchup: utreexo::Catchup,
-            _vtxs: Vec<VerifiedTx>,
-        ) {
+        fn store_block(&mut self, verified_block: VerifiedBlock, signature: Signature) {
             // TODO: update all proofs in the wallet with a catchup structure.
-            assert!(block.header.height == self.state.tip.height + 1);
-            self.blocks.push(block);
-            self.state = new_state;
+            assert!(verified_block.header.height == self.state.tip.height + 1);
+            self.state = verified_block.blockchain_state();
+            self.blocks.push(Block {
+                header: verified_block.header,
+                signature,
+                txs: verified_block.raw_txs,
+            });
         }
     }
 

--- a/blockchain/src/utreexo/forest.rs
+++ b/blockchain/src/utreexo/forest.rs
@@ -24,7 +24,7 @@ pub struct WorkForest {
 }
 
 /// Structure that helps auto-updating the proofs created for a previous state of a forest.
-#[derive(Clone, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Catchup {
     forest: WorkForest,           // forest that stores the inner nodes
     map: HashMap<Hash, Position>, // node hash -> new position offset for this node

--- a/demo/src/schema.rs
+++ b/demo/src/schema.rs
@@ -34,9 +34,4 @@ table! {
     }
 }
 
-allow_tables_to_appear_in_same_query!(
-    account_records,
-    asset_records,
-    block_records,
-    user_records,
-);
+allow_tables_to_appear_in_same_query!(account_records, asset_records, block_records, user_records,);

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -37,6 +37,9 @@ path = "../p2p"
 [dependencies.accounts]
 path = "../accounts"
 
+[dependencies.token]
+path = "../token"
+
 [dependencies.serde_json]
 git = "https://github.com/oleganza/json"
 #path = "../../../rust/serde-json"

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -5,6 +5,8 @@ authors = ["Oleg Andreev <oleganza@gmail.com>"]
 edition = "2018"
 
 [dependencies]
+curve25519-dalek = { version = "2", features = ["serde"] }
+merlin = "2"
 rand = "0.7"
 dotenv = "0.9.0"
 time = "^0.1"
@@ -20,5 +22,23 @@ toml = "0.5"
 [dependencies.blockchain]
 path = "../blockchain"
 
+[dependencies.zkvm]
+path = "../zkvm"
+
+[dependencies.keytree]
+path = "../keytree"
+
+[dependencies.musig]
+path = "../musig"
+
 [dependencies.p2p]
 path = "../p2p"
+
+[dependencies.accounts]
+path = "../accounts"
+
+[dependencies.serde_json]
+git = "https://github.com/oleganza/json"
+#path = "../../../rust/serde-json"
+branch = "binary-support"
+features = ["binary_hex"]

--- a/node/src/json.rs
+++ b/node/src/json.rs
@@ -1,0 +1,33 @@
+/// Force-decodes json string
+pub fn from_valid_json<'a, T>(string: &'a str) -> T
+where
+    T: serde::de::Deserialize<'a>,
+{
+    serde_json::de::from_str_with_binary_mode(string, serde_json::BinaryMode::Hex)
+        .expect("from_valid_json expects a valid JSON string")
+}
+
+/// Encodes object to JSON-encoded String
+pub fn to_json<T>(value: &T) -> String
+where
+    T: serde::ser::Serialize,
+{
+    let mut vec = Vec::with_capacity(128);
+    let mut ser = serde_json::ser::Serializer::with_formatter_and_binary_mode(
+        &mut vec,
+        serde_json::ser::PrettyFormatter::default(),
+        serde_json::BinaryMode::Hex,
+    );
+    value
+        .serialize(&mut ser)
+        .expect("Serialization should work");
+    String::from_utf8(vec).expect("Should not emit invalid UTF-8")
+}
+
+/// Encodes object to a JSON object
+pub fn to_json_value<T>(value: &T) -> serde_json::Value
+where
+    T: serde::ser::Serialize,
+{
+    serde_json::from_str(&to_json(value)).expect("Serialization to JSON value should work")
+}

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -9,9 +9,9 @@ mod api;
 mod bc;
 mod cli_args;
 mod config;
+mod json;
 mod ui;
 mod wallet;
-mod json;
 
 use bc::Blockchain;
 

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -1,3 +1,6 @@
+#[macro_use]
+extern crate serde_json;
+
 use cli_args::RunCommand;
 use config::Config;
 use std::path::Path;
@@ -8,6 +11,7 @@ mod cli_args;
 mod config;
 mod ui;
 mod wallet;
+mod json;
 
 use bc::Blockchain;
 

--- a/node/src/ui/bc_annotations.rs
+++ b/node/src/ui/bc_annotations.rs
@@ -1,0 +1,14 @@
+use serde_json::Value as JsonValue;
+use super::wallet::Balance;
+
+trait JsonAnnotated {
+    /// Encodes the object in a JSON value.
+    fn as_json_annotated(&self) -> JsonValue;
+}
+
+impl JsonAnnotated for Balance {
+    fn as_json_annotated(&self) -> JsonValue {
+        unimplemented!()
+    }
+}
+

--- a/node/src/ui/bc_annotations.rs
+++ b/node/src/ui/bc_annotations.rs
@@ -1,5 +1,5 @@
-use serde_json::Value as JsonValue;
 use super::wallet::Balance;
+use serde_json::Value as JsonValue;
 
 trait JsonAnnotated {
     /// Encodes the object in a JSON value.
@@ -11,4 +11,3 @@ impl JsonAnnotated for Balance {
         unimplemented!()
     }
 }
-

--- a/node/src/ui/mod.rs
+++ b/node/src/ui/mod.rs
@@ -1,9 +1,13 @@
 mod routes;
 mod templates;
 mod ui_helpers;
+mod bc_annotations;
 mod ws;
 
+use super::wallet;
+
 use std::net::SocketAddr;
+use std::time::SystemTime;
 
 use self::ui_helpers::UI;
 use crate::bc::BlockchainRef;
@@ -23,4 +27,12 @@ pub async fn launch(addr: SocketAddr, bc: BlockchainRef) {
 
     eprintln!("UI:  http://{}", &addr);
     warp::serve(routes::build(ui)).run(addr).await;
+}
+
+/// Returns the current system time.
+pub fn current_timestamp_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .expect("SystemTime should work")
+        .as_millis() as u64
 }

--- a/node/src/ui/mod.rs
+++ b/node/src/ui/mod.rs
@@ -1,7 +1,7 @@
+mod bc_annotations;
 mod routes;
 mod templates;
 mod ui_helpers;
-mod bc_annotations;
 mod ws;
 
 use super::wallet;

--- a/node/src/wallet.rs
+++ b/node/src/wallet.rs
@@ -686,18 +686,3 @@ impl Utxo {
         self.receiver.value
     }
 }
-
-fn shuffler<T>(
-    ctx: &mut T,
-    random: u64,
-    a: impl FnOnce(&mut T) -> (),
-    b: impl FnOnce(&mut T) -> (),
-) {
-    if random % 2 == 0 {
-        a(ctx);
-        b(ctx);
-    } else {
-        b(ctx);
-        a(ctx);
-    }
-}

--- a/node/src/wallet.rs
+++ b/node/src/wallet.rs
@@ -5,27 +5,28 @@ use std::mem;
 use curve25519_dalek::ristretto::CompressedRistretto;
 use curve25519_dalek::scalar::Scalar;
 use serde::{Deserialize, Serialize};
-use serde_json::Value as JsonValue;
 use zkvm::bulletproofs::BulletproofGens;
 
 use accounts::{Address, Receiver, Sequence, XprvDerivation, XpubDerivation};
 use keytree::{Xprv, Xpub};
 use musig::{Multisignature, VerificationKey};
 
-use super::json;
 use blockchain::utreexo;
-use blockchain::BlockchainState;
+use blockchain::{BlockTx, BlockchainState};
 use zkvm::{
-    Anchor, ClearValue, Contract, ContractID, PortableItem, Predicate, Tx, TxEntry, TxLog,
+    self, Anchor, ClearValue, Contract, ContractID, PortableItem, Predicate, Tx, TxEntry, TxLog,
     VerifiedTx,
 };
 
-use rand::thread_rng;
+use rand::{thread_rng, RngCore};
 
 /// Simple wallet implementation that keeps all data in a single serializable structure.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Wallet {
+    /// Prefix used by addresses in this wallet.
     address_label: String,
+
+    /// Extended pubkey from which all pubkeys and blinding factors are derived.
     xpub: Xpub,
 
     /// Current sequence number
@@ -71,6 +72,15 @@ pub struct Utxo {
     confirmed: bool,
     /// Indicates spentness: Some("was confirmed") for spent and None for unspent.
     spent: Option<bool>,
+}
+
+/// Errors that may occur during transaction creation.
+pub enum WalletError {
+    /// There are not enough funds to make the payment
+    InsufficientFunds,
+
+    /// Signing key (xprv) does not match the wallet's public key.
+    XprvMismatch,
 }
 
 /// Kind of the output: is it an incoming payment ("theirs") or a change ("ours")
@@ -220,6 +230,7 @@ impl Wallet {
         self.utxos.retain(|_, utxo| {
             // make sure to preserve confirmed utxos that are spent as unconfirmed
             if !utxo.confirmed {
+                // Erase spent status and restore the original confirmed flag
                 if let Some(was_confirmed) = utxo.spent {
                     utxo.spent = None;
                     utxo.confirmed = was_confirmed;
@@ -277,6 +288,271 @@ impl Wallet {
         }
     }
 
+    /// Returns all spendable utxos, including unconfirmed change utxos.
+    pub fn spendable_utxos(&self) -> impl Iterator<Item = Utxo> + '_ {
+        self.utxos.iter().filter_map(|(cid, utxo)| {
+            if utxo.spent == None && (utxo.confirmed || utxo.kind == OutputKind::Change) {
+                Some(utxo.clone())
+            } else {
+                None
+            }
+        })
+    }
+
+    /// Returns a list of asset balances, one per asset flavor.
+    pub fn balances(&self) -> impl Iterator<Item = Balance> {
+        self.spendable_utxos()
+            .fold(HashMap::new(), |mut hm: HashMap<Scalar, Balance>, utxo| {
+                let value = utxo.value();
+                match hm.get_mut(&value.flv) {
+                    Some(balance) => {
+                        balance.total += value.qty;
+                        balance.utxos.push(utxo.clone());
+                    }
+                    None => {
+                        hm.insert(
+                            value.flv.clone(),
+                            Balance {
+                                flavor: value.flv,
+                                total: value.qty,
+                                utxos: vec![utxo.clone()],
+                            },
+                        );
+                    }
+                }
+                hm
+            })
+            .into_iter()
+            .map(|(_, bal)| bal)
+    }
+
+    /// Attempts to build and sign a transaction paying a value to a given address.
+    ///
+    /// IMPORTANT: This does not immediately index the change output for use in the next tx.
+    /// You should add the returned transaction to the mempool and after it is verified,
+    /// index it in the wallet via `add_unconfirmed_tx`.
+    /// After that you can sign another transaction and use the full balance
+    /// that includes the change value from the previously signed transaction.
+    pub fn pay_to_address(
+        &mut self,
+        value: ClearValue,
+        address: Address,
+        xprv: &Xprv,
+        bp_gens: &BulletproofGens,
+    ) -> Result<BlockTx, WalletError> {
+        if xprv.as_xpub() != &self.xpub {
+            return Err(WalletError::XprvMismatch);
+        }
+
+        let (utxos_to_spend, change_clear_value) = value
+            .select_coins(self.spendable_utxos())
+            .ok_or(WalletError::InsufficientFunds)?;
+
+        let (seq, change_receiver) = self.create_receiver(change_clear_value);
+        let change_value = change_receiver.value;
+        let (payment_value, ct) = address.encrypt(value, thread_rng());
+
+        let coin_flip = thread_rng().next_u64();
+
+        // Sender forms a tx paying to this receiver.
+        //    Now recipient is receiving a new utxo, sender is receiving a change utxo.
+        let unsigned_tx = {
+            // Note: for clarity, we are not randomizing inputs and outputs in this example.
+            // The real transaction must randomize all the things
+            let program = zkvm::Program::build(|mut p| {
+                // claim all the collected utxos
+                for utxo in utxos_to_spend.iter() {
+                    p.push(utxo.contract_witness());
+                    p.input();
+                    p.signtx();
+                }
+
+                shuffler(
+                    &mut p,
+                    coin_flip,
+                    |p| {
+                        p.push(payment_value.qty);
+                        p.push(payment_value.flv);
+                    },
+                    |p| {
+                        p.push(change_value.qty);
+                        p.push(change_value.flv);
+                    },
+                );
+
+                p.cloak(utxos_to_spend.len(), 2);
+
+                shuffler(
+                    &mut p,
+                    coin_flip,
+                    |p| {
+                        p.push(address.predicate());
+                        p.output(1);
+                    },
+                    |p| {
+                        p.push(change_receiver.predicate());
+                        p.output(1);
+                    },
+                );
+
+                // add the payment ciphertext to the txlog
+                p.push(zkvm::String::Opaque(ct));
+                p.log();
+            });
+            let header = zkvm::TxHeader {
+                version: 1u64,
+                mintime_ms: 0u64,
+                maxtime_ms: u64::max_value(),
+            };
+
+            // Build the UnverifiedTx
+            zkvm::Prover::build_tx(program, header, &bp_gens)
+                .expect("We are supposed to compose the program correctly.")
+        };
+        let txid = unsigned_tx.txid;
+
+        // Sign the tx.
+        let tx = {
+            let mut signtx_transcript = merlin::Transcript::new(b"ZkVM.signtx");
+            signtx_transcript.append_message(b"txid", &txid);
+
+            // Derive individual signing keys for each input, according to its sequence number.
+            // In this example all inputs are coming from the same account (same xpub).
+            let signing_keys = utxos_to_spend
+                .iter()
+                .map(|utxo| xprv.key_at_sequence(utxo.sequence))
+                .collect::<Vec<_>>();
+
+            let sig = musig::Signature::sign_multi(
+                &signing_keys[..],
+                unsigned_tx.signing_instructions.clone(),
+                &mut signtx_transcript,
+            )
+            .unwrap();
+
+            unsigned_tx.sign(sig)
+        };
+
+        let utreexo_proofs = utxos_to_spend.into_iter().map(|utxo| utxo.proof).collect();
+
+        Ok(BlockTx {
+            tx,
+            proofs: utreexo_proofs,
+        })
+    }
+
+    /// Attempts to build and sign a transaction paying a value to a given receiver.
+    ///
+    /// IMPORTANT: This does not immediately index the change output for use in the next tx.
+    /// You should add the returned transaction to the mempool and after it is verified,
+    /// index it in the wallet via `add_unconfirmed_tx`.
+    /// After that you can sign another transaction and use the full balance
+    /// that includes the change value from the previously signed transaction.
+    pub fn pay_to_receiver(
+        &mut self,
+        value: ClearValue,
+        receiver: Receiver,
+        xprv: &Xprv,
+        bp_gens: &BulletproofGens,
+    ) -> Result<BlockTx, WalletError> {
+        if xprv.as_xpub() != &self.xpub {
+            return Err(WalletError::XprvMismatch);
+        }
+
+        let (utxos_to_spend, change_clear_value) = receiver
+            .value
+            .select_coins(self.spendable_utxos())
+            .ok_or(WalletError::InsufficientFunds)?;
+
+        let (seq, change_receiver) = self.create_receiver(change_clear_value);
+        let change_value = change_receiver.value;
+        let payment_value = receiver.blinded_value();
+
+        let coin_flip = thread_rng().next_u64();
+
+        // Sender forms a tx paying to this receiver.
+        //    Now recipient is receiving a new utxo, sender is receiving a change utxo.
+        let unsigned_tx = {
+            // Note: for clarity, we are not randomizing inputs and outputs in this example.
+            // The real transaction must randomize all the things
+            let program = zkvm::Program::build(|mut p| {
+                // claim all the collected utxos
+                for utxo in utxos_to_spend.iter() {
+                    p.push(utxo.contract_witness());
+                    p.input();
+                    p.signtx();
+                }
+
+                shuffler(
+                    &mut p,
+                    coin_flip,
+                    |p| {
+                        p.push(payment_value.qty);
+                        p.push(payment_value.flv);
+                    },
+                    |p| {
+                        p.push(change_value.qty);
+                        p.push(change_value.flv);
+                    },
+                );
+
+                p.cloak(utxos_to_spend.len(), 2);
+
+                shuffler(
+                    &mut p,
+                    coin_flip,
+                    |p| {
+                        p.push(receiver.predicate());
+                        p.output(1);
+                    },
+                    |p| {
+                        p.push(change_receiver.predicate());
+                        p.output(1);
+                    },
+                );
+            });
+            let header = zkvm::TxHeader {
+                version: 1u64,
+                mintime_ms: 0u64,
+                maxtime_ms: u64::max_value(),
+            };
+
+            // Build the UnverifiedTx
+            zkvm::Prover::build_tx(program, header, &bp_gens)
+                .expect("We are supposed to compose the program correctly.")
+        };
+        let txid = unsigned_tx.txid;
+
+        // Sign the tx.
+        let tx = {
+            let mut signtx_transcript = merlin::Transcript::new(b"ZkVM.signtx");
+            signtx_transcript.append_message(b"txid", &txid);
+
+            // Derive individual signing keys for each input, according to its sequence number.
+            // In this example all inputs are coming from the same account (same xpub).
+            let signing_keys = utxos_to_spend
+                .iter()
+                .map(|utxo| xprv.key_at_sequence(utxo.sequence))
+                .collect::<Vec<_>>();
+
+            let sig = musig::Signature::sign_multi(
+                &signing_keys[..],
+                unsigned_tx.signing_instructions.clone(),
+                &mut signtx_transcript,
+            )
+            .unwrap();
+
+            unsigned_tx.sign(sig)
+        };
+
+        let utreexo_proofs = utxos_to_spend.into_iter().map(|utxo| utxo.proof).collect();
+
+        Ok(BlockTx {
+            tx,
+            proofs: utreexo_proofs,
+        })
+    }
+
     /// Returns a pair of a sequence number and a receiver
     fn receiver_for_output(
         &self,
@@ -307,49 +583,6 @@ impl Wallet {
             }
         }
         None
-    }
-
-    /// Returns all spendable utxos, including unconfirmed change utxos.
-    pub fn spendable_utxos(&self) -> Vec<Utxo> {
-        self.utxos
-            .iter()
-            .filter_map(|(cid, utxo)| {
-                if utxo.spent == None && (utxo.confirmed || utxo.kind == OutputKind::Change) {
-                    Some(utxo.clone())
-                } else {
-                    None
-                }
-            })
-            .collect()
-    }
-
-    /// Returns a list of asset balances, one per asset flavor.
-    pub fn balances(&self) -> Vec<Balance> {
-        self.spendable_utxos()
-            .iter()
-            .fold(HashMap::new(), |mut hm: HashMap<Scalar, Balance>, utxo| {
-                let value = utxo.value();
-                match hm.get_mut(&value.flv) {
-                    Some(balance) => {
-                        balance.total += value.qty;
-                        balance.utxos.push(utxo.clone());
-                    }
-                    None => {
-                        hm.insert(
-                            value.flv.clone(),
-                            Balance {
-                                flavor: value.flv,
-                                total: value.qty,
-                                utxos: vec![utxo.clone()],
-                            },
-                        );
-                    }
-                }
-                hm
-            })
-            .into_iter()
-            .map(|(_, bal)| bal)
-            .collect()
     }
 }
 
@@ -393,781 +626,17 @@ impl Utxo {
     }
 }
 
-/*
-//////////////////////////////////////////////////////////////////////////
-//////////////////////////////////////////////////////////////////////////
-//////////////////////////////////////////////////////////////////////////
-//////////////////////////////////////////////////////////////////////////
-//////////////////////////////////////////////////////////////////////////
-//////////////////////////////////////////////////////////////////////////
-//////////////////////////////////////////////////////////////////////////
-//////////////////////////////////////////////////////////////////////////
-
-/// User's wallet account data
-#[derive(Clone, Serialize, Deserialize)]
-pub struct Account {
-    /// Name of the account
-    pub alias: String,
-
-    /// Account's root wallet key
-    // (we don't store it encrypted for now to make the demo simpler,
-    // but later we'll switch this to encrypted store)
-    pub xprv: Xprv,
-
-    /// User's account state
-    pub sequence: Sequence,
-
-    /// Annotated txs related to this account
-    pub txs: Vec<AnnotatedTx>,
-
-    /// All utxos known to the user - their own and outgoing.
-    pub utxos: Vec<UtxoWithStatus>,
-}
-
-
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct UtxoWithStatus {
-    status: UtxoStatus,
-    utxo: Utxo,
-}
-
-#[derive(Clone, Copy, Debug, Serialize, Deserialize)]
-pub enum UtxoStatus {
-    /// Account's incoming payment that is just promised by the sender.
-    /// Created even before the account has seen an unconfirmed transaction in a mempool.
-    Incoming,
-
-    /// Account's outgoing payment that belong to someone else.
-    /// We track these so we can annotate this account's transactions.
-    Outgoing,
-
-    /// Received utxo contains a utreexo proof that's always being updated.
-    Received,
-
-    /// Our utxo that we marked as spent. It's not removed right away until we process
-    /// transaction and annotate our own txs.
-    Spent,
-}
-
-/// Tx annotated with
-#[derive(Clone, Serialize, Deserialize)]
-pub struct AnnotatedTx {
-    pub block_height: Option<u64>,
-    pub raw_tx: zkvm::Tx,
-    // entry position, cleartext value
-    pub known_entries: Vec<(usize, ClearValue)>,
-}
-
-
-impl Account {
-    /// Creates a new user account with a privkey and pre-seeded collection of utxos
-    pub fn new(alias: impl Into<String>, root_xprv: &Xprv) -> Self {
-        let alias = alias.into();
-
-        let xprv = root_xprv.derive_intermediate_key(|t| {
-            t.append_message(b"account_alias", alias.as_bytes());
-        });
-
-        Self {
-            alias,
-            xprv,
-            sequence: 0,
-            txs: Vec::new(),
-            utxos: Vec::new(),
-        }
-    }
-
-    pub fn generate_receiver(&mut self, value: ClearValue) -> Receiver {
-        let seq = self.sequence;
-        self.sequence += 1;
-        self.xprv.as_xpub().receiver_at_sequence(seq, value)
-    }
-
-    /// Generates a bunch of initial utxos
-    pub fn mint_utxos(
-        &mut self,
-        mut anchor: Anchor,
-        flv: Scalar,
-        qtys: impl IntoIterator<Item = u64>,
-    ) -> (Vec<Utxo>, Anchor) {
-        let mut results = Vec::new();
-        for qty in qtys {
-            // anchors are not unique, but it's irrelevant for this test
-            anchor = anchor.ratchet();
-
-            let receiver_witness = self.generate_receiver(ClearValue { qty, flv });
-
-            results.push(Utxo {
-                receiver: receiver_witness.receiver,
-                sequence: receiver_witness.sequence,
-                anchor,
-                proof: utreexo::Proof::Transient,
-            });
-        }
-        (results, anchor)
-    }
-
-    pub fn remove_utxo(&mut self, contract_id: ContractID) -> Option<UtxoWithStatus> {
-        // Remove spent anchoring utxo
-        let maybe_i = self
-            .utxos
-            .iter()
-            .position(|o| o.contract_id() == contract_id);
-
-        if let Some(i) = maybe_i {
-            Some(self.utxos.remove(i))
-        } else {
-            None
-        }
-    }
-
-    pub fn spend_utxo(&mut self, contract_id: ContractID) {
-        // Remove spent anchoring utxo
-        let maybe_i = self
-            .utxos
-            .iter()
-            .position(|o| o.contract_id() == contract_id);
-
-        if let Some(i) = maybe_i {
-            self.utxos[i].mark_as_spent();
-        }
-    }
-
-    pub fn update_utxo_proofs(&mut self, catchup: &utreexo::Catchup) {
-        // Catch up utxoproofs for all the confirmed utxos.
-        let hasher = utreexo::utreexo_hasher();
-        let updated_proofs = self
-            .utxos
-            .iter()
-            .map(|utxo| {
-                catchup.update_proof(&utxo.contract_id(), utxo.any_utxo().proof.clone(), &hasher)
-            })
-            .collect::<Vec<_>>();
-
-        // Once all proofs are succesfully updated, apply them to our storage.
-        for (maybe_proof, utxo) in updated_proofs.into_iter().zip(self.utxos.iter_mut()) {
-            if let Ok(p) = maybe_proof {
-                utxo.as_mut_utxo().proof = p;
-            } else {
-                eprintln!("Proof update failed for {:?}", utxo);
-            }
-        }
-    }
-
-    /// Processes a block: detects spends, new outputs and updates utxo proofs.
-    pub fn process_block(
-        &mut self,
-        vtxs: &[VerifiedTx],
-        txs: &[Tx],
-        block_height: u64,
-        catchup: &utreexo::Catchup,
-    ) {
-        println!(
-            "Node {:?} is processing block {}...",
-            &self.alias, block_height
-        );
-
-        for (tx_index, vtx) in vtxs.iter().enumerate() {
-            if let Some(atx) = self.process_tx(&txs[tx_index], &vtx.log, Some(block_height)) {
-                self.txs.push(atx);
-            }
-        }
-
-        self.update_utxo_proofs(catchup);
-    }
-
-    /// Attempts to annotate the tx, and returns Some if this tx belongs to the account.
-    /// IMPORTANT: this modifies the wallet's utxo set.
-    pub fn process_tx(
-        &mut self,
-        tx: &Tx,
-        txlog: &TxLog,
-        block_height: Option<u64>,
-    ) -> Option<AnnotatedTx> {
-        let mut known_entries = Vec::new();
-        let mut our_tx = false;
-        for (entry_index, entry) in txlog.iter().enumerate() {
-            match entry {
-                TxEntry::Input(contract_id) => {
-                    if let Some(utxo) = self.remove_utxo(*contract_id) {
-                        known_entries.push((entry_index, utxo.value()));
-                        if let Some(_) = utxo.our_utxo() {
-                            our_tx = true;
-                        }
-                    }
-                }
-                TxEntry::Output(contract) => {
-                    let cid = contract.id();
-
-                    if let Some(i) = self.utxos.iter().position(|utxo| utxo.contract_id() == cid) {
-                        let utxo = &self.utxos[i];
-                        known_entries.push((entry_index, utxo.value()));
-                        if let Some(_) = utxo.our_utxo() {
-                            our_tx = true;
-                        }
-                        self.utxos[i].mark_incoming_as_received()
-                    }
-                }
-                _ => {}
-            }
-        }
-
-        if our_tx {
-            Some(AnnotatedTx {
-                block_height,
-                raw_tx: tx.clone(),
-                known_entries,
-            })
-        } else {
-            None
-        }
-    }
-
-    /// Returns a list of asset balances, one per asset flavor.
-    pub fn balances(&self) -> Vec<Balance> {
-        self.utxos
-            .iter()
-            .filter_map(UtxoWithStatus::spendable_utxo)
-            .fold(HashMap::new(), |mut hm: HashMap<Scalar, Balance>, utxo| {
-                let value = utxo.value();
-                match hm.get_mut(&value.flv) {
-                    Some(balance) => {
-                        balance.total += value.qty;
-                        balance.utxos.push(utxo.clone());
-                    }
-                    None => {
-                        hm.insert(
-                            value.flv.clone(),
-                            Balance {
-                                flavor: value.flv,
-                                total: value.qty,
-                                utxos: vec![utxo.clone()],
-                            },
-                        );
-                    }
-                }
-                hm
-            })
-            .into_iter()
-            .map(|(_, bal)| bal)
-            .collect()
-    }
-
-    // pub fn balances(&self) -> JsonValue {
-    //     // 1. Enumerate all confirmed utxos and stack up values by flavor.
-    //     // 2. Then, annotate each flavor with the asset name.
-
-    //     // HashMap<encoded flavor => (balance, Vec<Utxo>)>
-    //     let map = self
-    //         .utxos
-    //         .iter()
-    //         .filter_map(UtxoWithStatus::spendable_utxo)
-    //         .fold(
-    //             HashMap::new(),
-    //             |mut hm: HashMap<Vec<u8>, (u64, Vec<Utxo>)>, utxo| {
-    //                 let value = utxo.value();
-    //                 let key = value.flv.as_bytes().to_vec();
-    //                 match hm.get_mut(&key) {
-    //                     Some((total, list)) => {
-    //                         *total += value.qty;
-    //                         list.push(utxo.clone());
-    //                     }
-    //                     None => {
-    //                         hm.insert(key, (value.qty, vec![utxo.clone()]));
-    //                     }
-    //                 }
-    //                 hm
-    //             },
-    //         );
-    //     json!(map
-    //         .iter()
-    //         .map(|(flv, (balance, utxos))| {
-    //             let alias = assets
-    //                 .iter()
-    //                 .find(|&asset| asset.flavor().as_bytes() == &flv[..])
-    //                 .map(|x| x.alias.clone())
-    //                 .unwrap_or(hex::encode(flv));
-
-    //             json!({
-    //                 "alias": alias,
-    //                 "flavor_hex": hex::encode(&flv),
-    //                 "flv": flv,
-    //                 "qty": balance,
-    //                 "utxos": utxos.iter().map(|utxo| {
-    //                     json!({
-    //                         "contract_id": hex::encode(&utxo.contract_id()),
-    //                         "qty": utxo.value().qty
-    //                     })
-    //                 } ).collect::<Vec<_>>()
-    //             })
-    //         })
-    //         .collect::<Vec<_>>())
-    // }
-
-    /// Constructs an issuance transaction and a reply to the recipient.
-    pub fn prepare_issuance_tx(
-        &mut self,
-        issuance_key: Scalar,
-        issuance_metadata: zkvm::String,
-        payment_receiver: &accounts::Receiver,
-        bp_gens: &BulletproofGens,
-    ) -> Result<
-        (
-            zkvm::Tx,
-            zkvm::TxID,
-            Vec<utreexo::Proof>,
-            accounts::ReceiverReply,
-        ),
-        &'static str,
-    > {
-        let anchoring_utxo = &self
-            .utxos
-            .iter()
-            .filter_map(UtxoWithStatus::spendable_utxo)
-            .next()
-            .ok_or("Issuer needs at least one available UTXO to anchor the transaction.")?
-            .clone();
-        let change_receiver_witness = self.generate_receiver(anchoring_utxo.receiver.value);
-        let change_receiver = change_receiver_witness.receiver;
-        let change_seq = change_receiver_witness.sequence;
-
-        // Sender forms a tx paying to this receiver.
-        // Now recipient is receiving a new utxo, sender is receiving a change utxo.
-        let utx = {
-            // Note: for clarity, we are not randomizing inputs and outputs in this example.
-            // The real transaction must randomize all the things
-            let program = zkvm::Program::build(|p| {
-                p.push(anchoring_utxo.contract_witness());
-                p.input();
-                p.signtx();
-
-                let issuance_predicate =
-                    zkvm::Predicate::Key(zkvm::VerificationKey::from_secret(&issuance_key));
-
-                p.push(zkvm::Commitment::blinded(payment_receiver.value.qty)) // stack: qty
-                    .var() // stack: qty-var
-                    .push(zkvm::Commitment::unblinded(payment_receiver.value.flv)) // stack: qty-var, flv
-                    .var() // stack: qty-var, flv-var
-                    .push(issuance_metadata) // stack: qty-var, flv-var, data
-                    .push(issuance_predicate) // stack: qty-var, flv-var, data, flv-pred
-                    .issue() // stack: issue-contract
-                    .signtx(); // stack: issued-value
-
-                let pmnt = payment_receiver.blinded_value();
-                p.push(pmnt.qty);
-                p.push(pmnt.flv);
-
-                let change = change_receiver.blinded_value();
-                p.push(change.qty);
-                p.push(change.flv);
-
-                p.cloak(2, 2);
-
-                p.push(payment_receiver.predicate());
-                p.output(1);
-
-                p.push(change_receiver.predicate());
-                p.output(1);
-            });
-            let header = zkvm::TxHeader {
-                version: 1u64,
-                mintime_ms: 0u64,
-                maxtime_ms: u64::max_value(),
-            };
-
-            // Build the UnverifiedTx
-            zkvm::Prover::build_tx(program, header, &bp_gens)
-                .expect("We are supposed to compose the program correctly.")
-        };
-        let txid = utx.txid;
-
-        // Alice sends ReceiverReply to Bob with contract's anchor.
-        // Determine the payment contract's anchor and send it to Bob via ReceiverReply
-
-        // Collect all anchors for outputs.
-        let mut iterator = utx.txlog.iter().filter_map(|e| match e {
-            TxEntry::Output(contract) => Some(contract.anchor),
-            _ => None,
-        });
-        let payment_anchor = iterator
-            .next()
-            .expect("We have just built 2 outputs above.");
-        let change_anchor = iterator
-            .next()
-            .expect("We have just built 2 outputs above.");
-
-        let reply = accounts::ReceiverReply {
-            receiver_id: payment_receiver.id(),
-            anchor: payment_anchor,
-        };
-
-        let change_utxo = Utxo {
-            receiver: change_receiver,
-            anchor: change_anchor,
-            sequence: change_seq,
-            proof: utreexo::Proof::Transient,
-        };
-
-        // Sign the tx.
-        let tx = {
-            let mut signtx_transcript = merlin::Transcript::new(b"ZkVM.signtx");
-            signtx_transcript.append_message(b"txid", &utx.txid.0);
-
-            // Derive individual signing keys for each input, according to its sequence number.
-            // In this example all inputs are coming from the same account (same xpub).
-            let spending_key = self.xprv.key_at_sequence(anchoring_utxo.sequence);
-
-            let signing_keys = vec![spending_key, issuance_key];
-
-            let sig = musig::Signature::sign_multi(
-                &signing_keys[..],
-                utx.signing_instructions.clone(),
-                &mut signtx_transcript,
-            )
-            .unwrap();
-
-            utx.sign(sig)
-        };
-
-        let utxo_proofs = vec![anchoring_utxo.proof.clone()];
-        let cid = anchoring_utxo.contract_id();
-        self.spend_utxo(cid);
-
-        // Save the change utxo - it is spendable right away, via a chain of unconfirmed txs.
-        // FIXME: Strictly speaking, this is an "Incoming" utxo because we haven't yet published tx,
-        // but we currently don't do persistent changes when new txs land in a mempool,
-        // so if we mark it as Incoming, we won't be able to spend it until it's confirmed in a block.
-        // WARNING: This will cause an issue if the tx is not going to get into mempool.
-        //          However, it's similar to having mempool cleared -
-        //          we need a proper solution to rollback utxo storage when some
-        //          txs get fail to get into block.
-        self.utxos.push(change_utxo.received());
-
-        // remember the outgoing payment
-        self.utxos.push(
-            Utxo {
-                receiver: payment_receiver.clone(),
-                anchor: reply.anchor,
-                sequence: 0,
-                proof: utreexo::Proof::Transient,
-            }
-            .outgoing(),
-        );
-
-        Ok((tx, txid, utxo_proofs, reply))
-    }
-
-    /// Constructs a payment transaction and a reply to the recipient.
-    pub fn prepare_payment_tx(
-        &mut self,
-        payment_receiver: &accounts::Receiver,
-        bp_gens: &BulletproofGens,
-    ) -> Result<
-        (
-            zkvm::Tx,
-            zkvm::TxID,
-            Vec<utreexo::Proof>,
-            accounts::ReceiverReply,
-        ),
-        &'static str,
-    > {
-        let (spent_utxos, change_value) = payment_receiver
-            .value
-            .select_coins(
-                self.utxos
-                    .iter()
-                    .filter_map(UtxoWithStatus::spendable_utxo)
-                    .cloned(),
-            )
-            .ok_or("Insufficient funds!")?;
-
-        let maybe_change_receiver_witness = if change_value.qty > 0 {
-            Some(self.generate_receiver(change_value))
-        } else {
-            None
-        };
-
-        // Sender forms a tx paying to this receiver.
-        //    Now recipient is receiving a new utxo, sender is receiving a change utxo.
-        let utx = {
-            // Note: for clarity, we are not randomizing inputs and outputs in this example.
-            // The real transaction must randomize all the things
-            let program = zkvm::Program::build(|p| {
-                // claim all the collected utxos
-                for stored_utxo in spent_utxos.iter() {
-                    p.push(stored_utxo.contract_witness());
-                    p.input();
-                    p.signtx();
-                }
-
-                let pmnt = payment_receiver.blinded_value();
-                p.push(pmnt.qty);
-                p.push(pmnt.flv);
-
-                if let Some(crw) = &maybe_change_receiver_witness {
-                    let change = crw.receiver.blinded_value();
-                    p.push(change.qty);
-                    p.push(change.flv);
-                }
-
-                p.cloak(
-                    spent_utxos.len(),
-                    maybe_change_receiver_witness
-                        .as_ref()
-                        .map(|_| 2)
-                        .unwrap_or(1),
-                );
-
-                p.push(payment_receiver.predicate());
-                p.output(1);
-
-                if let Some(crw) = &maybe_change_receiver_witness {
-                    p.push(crw.receiver.predicate());
-                    p.output(1);
-                }
-            });
-            let header = zkvm::TxHeader {
-                version: 1u64,
-                mintime_ms: 0u64,
-                maxtime_ms: u64::max_value(),
-            };
-
-            // Build the UnverifiedTx
-            zkvm::Prover::build_tx(program, header, &bp_gens)
-                .expect("We are supposed to compose the program correctly.")
-        };
-        let txid = utx.txid;
-
-        // Alice sends ReceiverReply to Bob with contract's anchor.
-        // Determine the payment contract's anchor and send it to Bob via ReceiverReply
-
-        // Collect all anchors for outputs.
-        let mut iterator = utx.txlog.iter().filter_map(|e| match e {
-            TxEntry::Output(contract) => Some(contract.anchor),
-            _ => None,
-        });
-
-        let payment_anchor = iterator
-            .next()
-            .expect("We have just built the outputs above.");
-
-        let maybe_change_utxo = maybe_change_receiver_witness.map(|crw| {
-            let change_anchor = iterator
-                .next()
-                .expect("We have just built the outputs above.");
-            Utxo {
-                receiver: crw.receiver,
-                anchor: change_anchor,
-                sequence: crw.sequence,
-                proof: utreexo::Proof::Transient,
-            }
-        });
-
-        let reply = accounts::ReceiverReply {
-            receiver_id: payment_receiver.id(),
-            anchor: payment_anchor,
-        };
-
-        // Sign the tx.
-        let tx = {
-            let mut signtx_transcript = merlin::Transcript::new(b"ZkVM.signtx");
-            signtx_transcript.append_message(b"txid", &utx.txid.0);
-
-            // Derive individual signing keys for each input, according to its sequence number.
-            // In this example all inputs are coming from the same account (same xpub).
-            let signing_keys = spent_utxos
-                .iter()
-                .map(|utxo| self.xprv.key_at_sequence(utxo.sequence))
-                .collect::<Vec<_>>();
-
-            let sig = musig::Signature::sign_multi(
-                &signing_keys[..],
-                utx.signing_instructions.clone(),
-                &mut signtx_transcript,
-            )
-            .unwrap();
-
-            utx.sign(sig)
-        };
-
-        let utxo_proofs = spent_utxos
-            .iter()
-            .map(|utxo| utxo.proof.clone())
-            .collect::<Vec<_>>();
-
-        let contract_ids = spent_utxos
-            .iter()
-            .map(|utxo| utxo.contract_id())
-            .collect::<Vec<_>>();
-
-        // Mark all spent utxos.
-        for cid in contract_ids.iter() {
-            self.spend_utxo(*cid);
-        }
-
-        // Save the change utxo
-        if let Some(change_utxo) = maybe_change_utxo {
-            // Save the change utxo - it is spendable right away, via a chain of unconfirmed txs.
-            // FIXME: Strictly speaking, this is an "Incoming" utxo because we haven't yet published tx,
-            // but we currently don't do persistent changes when new txs land in a mempool,
-            // so if we mark it as Incoming, we won't be able to spend it until it's confirmed in a block.
-            // WARNING: This will cause an issue if the tx is not going to get into mempool.
-            //          However, it's similar to having mempool cleared -
-            //          we need a proper solution to rollback utxo storage when some
-            //          txs get fail to get into block.
-            self.utxos.push(change_utxo.received());
-        }
-
-        // Remember the outgoing payment
-        self.utxos.push(
-            Utxo {
-                receiver: payment_receiver.clone(),
-                anchor: reply.anchor,
-                sequence: 0,
-                proof: utreexo::Proof::Transient,
-            }
-            .outgoing(),
-        );
-
-        Ok((tx, txid, utxo_proofs, reply))
-    }
-
-    /// Converts the wallet to a JSON object
-    pub fn to_json(&self) -> JsonValue {
-        json::to_json_value(&self)
+fn shuffler<T>(
+    ctx: &mut T,
+    random: u64,
+    a: impl FnOnce(&mut T) -> (),
+    b: impl FnOnce(&mut T) -> (),
+) {
+    if random % 2 == 0 {
+        a(ctx);
+        b(ctx);
+    } else {
+        b(ctx);
+        a(ctx);
     }
 }
-
-// impl AnnotatedTx {
-//     pub fn tx_details(&self, assets: &[AssetRecord]) -> JsonValue {
-//         let precomputed_tx = self
-//             .raw_tx
-//             .precompute()
-//             .expect("Our blockchain does not have invalid transactions.");
-
-//         json!({
-//             "block_height": self.block_height,
-//             "generic_tx": BlockRecord::tx_details(&self.raw_tx),
-//             "inputs": &precomputed_tx.log.iter().enumerate().filter_map(|(i,e)| {
-//                 e.as_input().map(|cid| {
-//                     self.annotated_entry(i, cid, assets)
-//                 })
-//             })
-//             .collect::<Vec<_>>(),
-
-//             "outputs": &precomputed_tx.log.iter().enumerate().filter_map(|(i,e)| {
-//                 e.as_output().map(|c| {
-//                     self.annotated_entry(i, c.id(), assets)
-//                 })
-//             })
-//             .collect::<Vec<_>>(),
-//         })
-//     }
-
-//     fn find_known_value(&self, entry_index: usize) -> Option<ClearValue> {
-//         self.known_entries
-//             .iter()
-//             .find(|&(i, _)| *i == entry_index)
-//             .map(|(_, value)| *value)
-//     }
-
-//     fn annotated_entry(
-//         &self,
-//         entry_index: usize,
-//         cid: ContractID,
-//         assets: &[AssetRecord],
-//     ) -> JsonValue {
-//         json!({
-//             "id": &util::to_json_value(&cid),
-//             "value": self.find_known_value(entry_index).map(|value| {
-//                 // If found a known entry, find asset alias for its flavor.
-//                 let maybe_alias = assets
-//                     .iter()
-//                     .find(|&asset| asset.flavor() == value.flv)
-//                     .map(|x| x.alias.clone());
-//                 json!({
-//                     "qty": value.qty,
-//                     "flv": &util::to_json_value(&value.flv),
-//                     "alias": maybe_alias
-//                 })
-//             })
-//         })
-//     }
-// }
-
-
-
-impl UtxoWithStatus {
-    pub fn value(&self) -> ClearValue {
-        self.any_utxo().value()
-    }
-
-    /// Convert utxo to a Contract instance
-    pub fn contract(&self) -> Contract {
-        self.any_utxo().contract()
-    }
-
-    /// Returns the UTXO ID
-    pub fn contract_id(&self) -> ContractID {
-        self.any_utxo().contract_id()
-    }
-
-    pub fn mark_as_spent(&mut self) {
-        self.status = UtxoStatus::Spent;
-    }
-
-    pub fn mark_incoming_as_received(&mut self) {
-        match self.status {
-            UtxoStatus::Incoming => {
-                self.status = UtxoStatus::Received;
-            }
-            UtxoStatus::Received => {}
-            UtxoStatus::Spent => {}
-            UtxoStatus::Outgoing => {}
-        }
-    }
-
-    pub fn into_utxo(self) -> Utxo {
-        self.utxo
-    }
-
-    pub fn as_mut_utxo(&mut self) -> &mut Utxo {
-        &mut self.utxo
-    }
-
-    pub fn any_utxo(&self) -> &Utxo {
-        &self.utxo
-    }
-
-    /// A utxo that belongs to us, even if not spendable yet.
-    pub fn our_utxo(&self) -> Option<&Utxo> {
-        match self.status {
-            UtxoStatus::Incoming => Some(&self.utxo),
-            UtxoStatus::Received => Some(&self.utxo),
-            UtxoStatus::Spent => Some(&self.utxo),
-            UtxoStatus::Outgoing => None,
-        }
-    }
-
-    /// A utxo that belongs to us, which is also safe to spend.
-    pub fn spendable_utxo(&self) -> Option<&Utxo> {
-        match self.status {
-            UtxoStatus::Incoming => None,
-            UtxoStatus::Received => Some(&self.utxo),
-            UtxoStatus::Spent => None,
-            UtxoStatus::Outgoing => None,
-        }
-    }
-
-    /// A utxo that we know about, but it's not ours.
-    pub fn outgoing_utxo(&self) -> Option<&Utxo> {
-        match self.status {
-            UtxoStatus::Incoming => None,
-            UtxoStatus::Received => None,
-            UtxoStatus::Spent => None,
-            UtxoStatus::Outgoing => Some(&self.utxo),
-        }
-    }
-}
-
-*/

--- a/node/src/wallet.rs
+++ b/node/src/wallet.rs
@@ -1,1 +1,851 @@
+use std::collections::HashMap;
+
+use curve25519_dalek::scalar::Scalar;
+use zkvm::bulletproofs::BulletproofGens;
+use serde::{Deserialize, Serialize};
+use serde_json::Value as JsonValue;
+
+use accounts::{Receiver, ReceiverWitness, XprvDerivation};
+use keytree::Xprv;
+use musig::Multisignature;
+
+use blockchain::utreexo;
+use zkvm::{Anchor, ClearValue, Contract, ContractID, Tx, TxEntry, TxLog, VerifiedTx};
+use super::json;
+
+/// User's wallet account data
+#[derive(Clone, Serialize, Deserialize)]
+pub struct Account {
+    /// Name of the account
+    pub alias: String,
+
+    /// Account's root wallet key
+    // (we don't store it encrypted for now to make the demo simpler,
+    // but later we'll switch this to encrypted store)
+    pub xprv: Xprv,
+
+    /// User's account state
+    pub sequence: u64,
+
+    /// Annotated txs related to this account
+    pub txs: Vec<AnnotatedTx>,
+
+    /// All utxos known to the user - their own and outgoing.
+    pub utxos: Vec<UtxoWithStatus>,
+}
+
+/// Contract details of the utxo
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct Utxo {
+    pub receiver: Receiver,
+    pub anchor: Anchor,
+    pub sequence: u64,         // 0 for outgoing utxos
+    pub proof: utreexo::Proof, // transient for outgoing and unconfirmed utxos
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct UtxoWithStatus {
+    status: UtxoStatus,
+    utxo: Utxo,
+}
+
+#[derive(Clone, Copy, Debug, Serialize, Deserialize)]
+pub enum UtxoStatus {
+    /// Account's incoming payment that is just promised by the sender.
+    /// Created even before the account has seen an unconfirmed transaction in a mempool.
+    Incoming,
+
+    /// Account's outgoing payment that belong to someone else.
+    /// We track these so we can annotate this account's transactions.
+    Outgoing,
+
+    /// Received utxo contains a utreexo proof that's always being updated.
+    Received,
+
+    /// Our utxo that we marked as spent. It's not removed right away until we process
+    /// transaction and annotate our own txs.
+    Spent,
+}
+
+
+/// Tx annotated with
+#[derive(Clone, Serialize, Deserialize)]
+pub struct AnnotatedTx {
+    pub block_height: Option<u64>,
+    pub raw_tx: zkvm::Tx,
+    // entry position, cleartext value
+    pub known_entries: Vec<(usize, ClearValue)>,
+}
+
+/// Balance of a certain asset that consists of a number of spendable UTXOs.
+#[derive(Clone,Debug,Serialize,Deserialize)]
+pub struct Balance {
+    /// Flavor of the asset in this balance
+    pub flavor: Scalar,
+
+    /// Total qty of the asset
+    pub total: u64,
+
+    /// List of spendable utxos.
+    pub utxos: Vec<Utxo>,
+}
+
+impl Account {
+    /// Creates a new user account with a privkey and pre-seeded collection of utxos
+    pub fn new(alias: impl Into<String>, root_xprv: &Xprv) -> Self {
+        let alias = alias.into();
+
+        let xprv = root_xprv.derive_intermediate_key(|t| {
+            t.append_message(b"account_alias", alias.as_bytes());
+        });
+
+        Self {
+            alias,
+            xprv,
+            sequence: 0,
+            txs: Vec::new(),
+            utxos: Vec::new(),
+        }
+    }
+
+    pub fn generate_receiver(&mut self, value: ClearValue) -> ReceiverWitness {
+        let seq = self.sequence;
+        self.sequence += 1;
+        ReceiverWitness::new(self.xprv.as_xpub(), seq, value)
+    }
+
+    /// Generates a bunch of initial utxos
+    pub fn mint_utxos(
+        &mut self,
+        mut anchor: Anchor,
+        flv: Scalar,
+        qtys: impl IntoIterator<Item = u64>,
+    ) -> (Vec<Utxo>, Anchor) {
+        let mut results = Vec::new();
+        for qty in qtys {
+            // anchors are not unique, but it's irrelevant for this test
+            anchor = anchor.ratchet();
+
+            let receiver_witness = self.generate_receiver(ClearValue { qty, flv });
+
+            results.push(Utxo {
+                receiver: receiver_witness.receiver,
+                sequence: receiver_witness.sequence,
+                anchor,
+                proof: utreexo::Proof::Transient,
+            });
+        }
+        (results, anchor)
+    }
+
+    pub fn remove_utxo(&mut self, contract_id: ContractID) -> Option<UtxoWithStatus> {
+        // Remove spent anchoring utxo
+        let maybe_i = self
+            .utxos
+            .iter()
+            .position(|o| o.contract_id() == contract_id);
+
+        if let Some(i) = maybe_i {
+            Some(self.utxos.remove(i))
+        } else {
+            None
+        }
+    }
+
+    pub fn spend_utxo(&mut self, contract_id: ContractID) {
+        // Remove spent anchoring utxo
+        let maybe_i = self
+            .utxos
+            .iter()
+            .position(|o| o.contract_id() == contract_id);
+
+        if let Some(i) = maybe_i {
+            self.utxos[i].mark_as_spent();
+        }
+    }
+
+    pub fn update_utxo_proofs(&mut self, catchup: &utreexo::Catchup) {
+        // Catch up utxoproofs for all the confirmed utxos.
+        let hasher = utreexo::utreexo_hasher();
+        let updated_proofs = self
+            .utxos
+            .iter()
+            .map(|utxo| {
+                catchup.update_proof(&utxo.contract_id(), utxo.any_utxo().proof.clone(), &hasher)
+            })
+            .collect::<Vec<_>>();
+
+        // Once all proofs are succesfully updated, apply them to our storage.
+        for (maybe_proof, utxo) in updated_proofs.into_iter().zip(self.utxos.iter_mut()) {
+            if let Ok(p) = maybe_proof {
+                utxo.as_mut_utxo().proof = p;
+            } else {
+                eprintln!("Proof update failed for {:?}", utxo);
+            }
+        }
+    }
+
+    /// Processes a block: detects spends, new outputs and updates utxo proofs.
+    pub fn process_block(
+        &mut self,
+        vtxs: &[VerifiedTx],
+        txs: &[Tx],
+        block_height: u64,
+        catchup: &utreexo::Catchup,
+    ) {
+        println!(
+            "Node {:?} is processing block {}...",
+            &self.alias, block_height
+        );
+
+        for (tx_index, vtx) in vtxs.iter().enumerate() {
+            if let Some(atx) = self.process_tx(&txs[tx_index], &vtx.log, Some(block_height)) {
+                self.txs.push(atx);
+            }
+        }
+
+        self.update_utxo_proofs(catchup);
+    }
+
+    /// Attempts to annotate the tx, and returns Some if this tx belongs to the account.
+    /// IMPORTANT: this modifies the wallet's utxo set.
+    pub fn process_tx(
+        &mut self,
+        tx: &Tx,
+        txlog: &TxLog,
+        block_height: Option<u64>,
+    ) -> Option<AnnotatedTx> {
+        let mut known_entries = Vec::new();
+        let mut our_tx = false;
+        for (entry_index, entry) in txlog.iter().enumerate() {
+            match entry {
+                TxEntry::Input(contract_id) => {
+                    if let Some(utxo) = self.remove_utxo(*contract_id) {
+                        known_entries.push((entry_index, utxo.value()));
+                        if let Some(_) = utxo.our_utxo() {
+                            our_tx = true;
+                        }
+                    }
+                }
+                TxEntry::Output(contract) => {
+                    let cid = contract.id();
+
+                    if let Some(i) = self.utxos.iter().position(|utxo| utxo.contract_id() == cid) {
+                        let utxo = &self.utxos[i];
+                        known_entries.push((entry_index, utxo.value()));
+                        if let Some(_) = utxo.our_utxo() {
+                            our_tx = true;
+                        }
+                        self.utxos[i].mark_incoming_as_received()
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        if our_tx {
+            Some(AnnotatedTx {
+                block_height,
+                raw_tx: tx.clone(),
+                known_entries,
+            })
+        } else {
+            None
+        }
+    }
+
+    /// Returns a list of asset balances, one per asset flavor.
+    pub fn balances(&self) -> Vec<Balance> {
+        self
+            .utxos
+            .iter()
+            .filter_map(UtxoWithStatus::spendable_utxo)
+            .fold(
+                HashMap::new(),
+                |mut hm: HashMap<Scalar, Balance>, utxo| {
+                    let value = utxo.value();
+                    match hm.get_mut(&value.flv) {
+                        Some(balance) => {
+                            balance.total += value.qty;
+                            balance.utxos.push(utxo.clone());
+                        }
+                        None => {
+                            hm.insert(value.flv.clone(), Balance {
+                                flavor: value.flv,
+                                total: value.qty,
+                                utxos: vec![utxo.clone()]
+                            });
+                        }
+                    }
+                    hm
+                },
+            ).into_iter().map(|(_, bal)| bal).collect()
+    }
+
+
+    // pub fn balances(&self) -> JsonValue {
+    //     // 1. Enumerate all confirmed utxos and stack up values by flavor.
+    //     // 2. Then, annotate each flavor with the asset name.
+
+    //     // HashMap<encoded flavor => (balance, Vec<Utxo>)>
+    //     let map = self
+    //         .utxos
+    //         .iter()
+    //         .filter_map(UtxoWithStatus::spendable_utxo)
+    //         .fold(
+    //             HashMap::new(),
+    //             |mut hm: HashMap<Vec<u8>, (u64, Vec<Utxo>)>, utxo| {
+    //                 let value = utxo.value();
+    //                 let key = value.flv.as_bytes().to_vec();
+    //                 match hm.get_mut(&key) {
+    //                     Some((total, list)) => {
+    //                         *total += value.qty;
+    //                         list.push(utxo.clone());
+    //                     }
+    //                     None => {
+    //                         hm.insert(key, (value.qty, vec![utxo.clone()]));
+    //                     }
+    //                 }
+    //                 hm
+    //             },
+    //         );
+    //     json!(map
+    //         .iter()
+    //         .map(|(flv, (balance, utxos))| {
+    //             let alias = assets
+    //                 .iter()
+    //                 .find(|&asset| asset.flavor().as_bytes() == &flv[..])
+    //                 .map(|x| x.alias.clone())
+    //                 .unwrap_or(hex::encode(flv));
+
+    //             json!({
+    //                 "alias": alias,
+    //                 "flavor_hex": hex::encode(&flv),
+    //                 "flv": flv,
+    //                 "qty": balance,
+    //                 "utxos": utxos.iter().map(|utxo| {
+    //                     json!({
+    //                         "contract_id": hex::encode(&utxo.contract_id()),
+    //                         "qty": utxo.value().qty
+    //                     })
+    //                 } ).collect::<Vec<_>>()
+    //             })
+    //         })
+    //         .collect::<Vec<_>>())
+    // }
+
+    /// Constructs an issuance transaction and a reply to the recipient.
+    pub fn prepare_issuance_tx(
+        &mut self,
+        issuance_key: Scalar,
+        issuance_metadata: zkvm::String,
+        payment_receiver: &accounts::Receiver,
+        bp_gens: &BulletproofGens,
+    ) -> Result<
+        (
+            zkvm::Tx,
+            zkvm::TxID,
+            Vec<utreexo::Proof>,
+            accounts::ReceiverReply,
+        ),
+        &'static str,
+    > {
+        let anchoring_utxo = &self
+            .utxos
+            .iter()
+            .filter_map(UtxoWithStatus::spendable_utxo)
+            .next()
+            .ok_or("Issuer needs at least one available UTXO to anchor the transaction.")?
+            .clone();
+        let change_receiver_witness = self.generate_receiver(anchoring_utxo.receiver.value);
+        let change_receiver = change_receiver_witness.receiver;
+        let change_seq = change_receiver_witness.sequence;
+
+        // Sender forms a tx paying to this receiver.
+        // Now recipient is receiving a new utxo, sender is receiving a change utxo.
+        let utx = {
+            // Note: for clarity, we are not randomizing inputs and outputs in this example.
+            // The real transaction must randomize all the things
+            let program = zkvm::Program::build(|p| {
+                p.push(anchoring_utxo.contract_witness());
+                p.input();
+                p.signtx();
+
+                let issuance_predicate =
+                    zkvm::Predicate::Key(zkvm::VerificationKey::from_secret(&issuance_key));
+
+                p.push(zkvm::Commitment::blinded(payment_receiver.value.qty)) // stack: qty
+                    .var() // stack: qty-var
+                    .push(zkvm::Commitment::unblinded(payment_receiver.value.flv)) // stack: qty-var, flv
+                    .var() // stack: qty-var, flv-var
+                    .push(issuance_metadata) // stack: qty-var, flv-var, data
+                    .push(issuance_predicate) // stack: qty-var, flv-var, data, flv-pred
+                    .issue() // stack: issue-contract
+                    .signtx(); // stack: issued-value
+
+                let pmnt = payment_receiver.blinded_value();
+                p.push(pmnt.qty);
+                p.push(pmnt.flv);
+
+                let change = change_receiver.blinded_value();
+                p.push(change.qty);
+                p.push(change.flv);
+
+                p.cloak(2, 2);
+
+                p.push(payment_receiver.predicate());
+                p.output(1);
+
+                p.push(change_receiver.predicate());
+                p.output(1);
+            });
+            let header = zkvm::TxHeader {
+                version: 1u64,
+                mintime_ms: 0u64,
+                maxtime_ms: u64::max_value(),
+            };
+
+            // Build the UnverifiedTx
+            zkvm::Prover::build_tx(program, header, &bp_gens)
+                .expect("We are supposed to compose the program correctly.")
+        };
+        let txid = utx.txid;
+
+        // Alice sends ReceiverReply to Bob with contract's anchor.
+        // Determine the payment contract's anchor and send it to Bob via ReceiverReply
+
+        // Collect all anchors for outputs.
+        let mut iterator = utx.txlog.iter().filter_map(|e| match e {
+            TxEntry::Output(contract) => Some(contract.anchor),
+            _ => None,
+        });
+        let payment_anchor = iterator
+            .next()
+            .expect("We have just built 2 outputs above.");
+        let change_anchor = iterator
+            .next()
+            .expect("We have just built 2 outputs above.");
+
+        let reply = accounts::ReceiverReply {
+            receiver_id: payment_receiver.id(),
+            anchor: payment_anchor,
+        };
+
+        let change_utxo = Utxo {
+            receiver: change_receiver,
+            anchor: change_anchor,
+            sequence: change_seq,
+            proof: utreexo::Proof::Transient,
+        };
+
+        // Sign the tx.
+        let tx = {
+            let mut signtx_transcript = merlin::Transcript::new(b"ZkVM.signtx");
+            signtx_transcript.append_message(b"txid", &utx.txid.0);
+
+            // Derive individual signing keys for each input, according to its sequence number.
+            // In this example all inputs are coming from the same account (same xpub).
+            let spending_key = self.xprv.key_at_sequence(anchoring_utxo.sequence);
+
+            let signing_keys = vec![spending_key, issuance_key];
+
+            let sig = musig::Signature::sign_multi(
+                &signing_keys[..],
+                utx.signing_instructions.clone(),
+                &mut signtx_transcript,
+            )
+            .unwrap();
+
+            utx.sign(sig)
+        };
+
+        let utxo_proofs = vec![anchoring_utxo.proof.clone()];
+        let cid = anchoring_utxo.contract_id();
+        self.spend_utxo(cid);
+
+        // Save the change utxo - it is spendable right away, via a chain of unconfirmed txs.
+        // FIXME: Strictly speaking, this is an "Incoming" utxo because we haven't yet published tx,
+        // but we currently don't do persistent changes when new txs land in a mempool,
+        // so if we mark it as Incoming, we won't be able to spend it until it's confirmed in a block.
+        // WARNING: This will cause an issue if the tx is not going to get into mempool.
+        //          However, it's similar to having mempool cleared -
+        //          we need a proper solution to rollback utxo storage when some
+        //          txs get fail to get into block.
+        self.utxos.push(change_utxo.received());
+
+        // remember the outgoing payment
+        self.utxos.push(
+            Utxo {
+                receiver: payment_receiver.clone(),
+                anchor: reply.anchor,
+                sequence: 0,
+                proof: utreexo::Proof::Transient,
+            }
+            .outgoing(),
+        );
+
+        Ok((tx, txid, utxo_proofs, reply))
+    }
+
+    /// Constructs a payment transaction and a reply to the recipient.
+    pub fn prepare_payment_tx(
+        &mut self,
+        payment_receiver: &accounts::Receiver,
+        bp_gens: &BulletproofGens,
+    ) -> Result<
+        (
+            zkvm::Tx,
+            zkvm::TxID,
+            Vec<utreexo::Proof>,
+            accounts::ReceiverReply,
+        ),
+        &'static str,
+    > {
+        let (spent_utxos, change_value) = payment_receiver
+            .value
+            .select_coins(
+                self.utxos
+                    .iter()
+                    .filter_map(UtxoWithStatus::spendable_utxo)
+                    .cloned(),
+            )
+            .ok_or("Insufficient funds!")?;
+
+        let maybe_change_receiver_witness = if change_value.qty > 0 {
+            Some(self.generate_receiver(change_value))
+        } else {
+            None
+        };
+
+        // Sender forms a tx paying to this receiver.
+        //    Now recipient is receiving a new utxo, sender is receiving a change utxo.
+        let utx = {
+            // Note: for clarity, we are not randomizing inputs and outputs in this example.
+            // The real transaction must randomize all the things
+            let program = zkvm::Program::build(|p| {
+                // claim all the collected utxos
+                for stored_utxo in spent_utxos.iter() {
+                    p.push(stored_utxo.contract_witness());
+                    p.input();
+                    p.signtx();
+                }
+
+                let pmnt = payment_receiver.blinded_value();
+                p.push(pmnt.qty);
+                p.push(pmnt.flv);
+
+                if let Some(crw) = &maybe_change_receiver_witness {
+                    let change = crw.receiver.blinded_value();
+                    p.push(change.qty);
+                    p.push(change.flv);
+                }
+
+                p.cloak(
+                    spent_utxos.len(),
+                    maybe_change_receiver_witness
+                        .as_ref()
+                        .map(|_| 2)
+                        .unwrap_or(1),
+                );
+
+                p.push(payment_receiver.predicate());
+                p.output(1);
+
+                if let Some(crw) = &maybe_change_receiver_witness {
+                    p.push(crw.receiver.predicate());
+                    p.output(1);
+                }
+            });
+            let header = zkvm::TxHeader {
+                version: 1u64,
+                mintime_ms: 0u64,
+                maxtime_ms: u64::max_value(),
+            };
+
+            // Build the UnverifiedTx
+            zkvm::Prover::build_tx(program, header, &bp_gens)
+                .expect("We are supposed to compose the program correctly.")
+        };
+        let txid = utx.txid;
+
+        // Alice sends ReceiverReply to Bob with contract's anchor.
+        // Determine the payment contract's anchor and send it to Bob via ReceiverReply
+
+        // Collect all anchors for outputs.
+        let mut iterator = utx.txlog.iter().filter_map(|e| match e {
+            TxEntry::Output(contract) => Some(contract.anchor),
+            _ => None,
+        });
+
+        let payment_anchor = iterator
+            .next()
+            .expect("We have just built the outputs above.");
+
+        let maybe_change_utxo = maybe_change_receiver_witness.map(|crw| {
+            let change_anchor = iterator
+                .next()
+                .expect("We have just built the outputs above.");
+            Utxo {
+                receiver: crw.receiver,
+                anchor: change_anchor,
+                sequence: crw.sequence,
+                proof: utreexo::Proof::Transient,
+            }
+        });
+
+        let reply = accounts::ReceiverReply {
+            receiver_id: payment_receiver.id(),
+            anchor: payment_anchor,
+        };
+
+        // Sign the tx.
+        let tx = {
+            let mut signtx_transcript = merlin::Transcript::new(b"ZkVM.signtx");
+            signtx_transcript.append_message(b"txid", &utx.txid.0);
+
+            // Derive individual signing keys for each input, according to its sequence number.
+            // In this example all inputs are coming from the same account (same xpub).
+            let signing_keys = spent_utxos
+                .iter()
+                .map(|utxo| self.xprv.key_at_sequence(utxo.sequence))
+                .collect::<Vec<_>>();
+
+            let sig = musig::Signature::sign_multi(
+                &signing_keys[..],
+                utx.signing_instructions.clone(),
+                &mut signtx_transcript,
+            )
+            .unwrap();
+
+            utx.sign(sig)
+        };
+
+        let utxo_proofs = spent_utxos
+            .iter()
+            .map(|utxo| utxo.proof.clone())
+            .collect::<Vec<_>>();
+
+        let contract_ids = spent_utxos
+            .iter()
+            .map(|utxo| utxo.contract_id())
+            .collect::<Vec<_>>();
+
+        // Mark all spent utxos.
+        for cid in contract_ids.iter() {
+            self.spend_utxo(*cid);
+        }
+
+        // Save the change utxo
+        if let Some(change_utxo) = maybe_change_utxo {
+            // Save the change utxo - it is spendable right away, via a chain of unconfirmed txs.
+            // FIXME: Strictly speaking, this is an "Incoming" utxo because we haven't yet published tx,
+            // but we currently don't do persistent changes when new txs land in a mempool,
+            // so if we mark it as Incoming, we won't be able to spend it until it's confirmed in a block.
+            // WARNING: This will cause an issue if the tx is not going to get into mempool.
+            //          However, it's similar to having mempool cleared -
+            //          we need a proper solution to rollback utxo storage when some
+            //          txs get fail to get into block.
+            self.utxos.push(change_utxo.received());
+        }
+
+        // Remember the outgoing payment
+        self.utxos.push(
+            Utxo {
+                receiver: payment_receiver.clone(),
+                anchor: reply.anchor,
+                sequence: 0,
+                proof: utreexo::Proof::Transient,
+            }
+            .outgoing(),
+        );
+
+        Ok((tx, txid, utxo_proofs, reply))
+    }
+
+    /// Converts the wallet to a JSON object
+    pub fn to_json(&self) -> JsonValue {
+        json::to_json_value(&self)
+    }
+}
+
+// impl AnnotatedTx {
+//     pub fn tx_details(&self, assets: &[AssetRecord]) -> JsonValue {
+//         let precomputed_tx = self
+//             .raw_tx
+//             .precompute()
+//             .expect("Our blockchain does not have invalid transactions.");
+
+//         json!({
+//             "block_height": self.block_height,
+//             "generic_tx": BlockRecord::tx_details(&self.raw_tx),
+//             "inputs": &precomputed_tx.log.iter().enumerate().filter_map(|(i,e)| {
+//                 e.as_input().map(|cid| {
+//                     self.annotated_entry(i, cid, assets)
+//                 })
+//             })
+//             .collect::<Vec<_>>(),
+
+//             "outputs": &precomputed_tx.log.iter().enumerate().filter_map(|(i,e)| {
+//                 e.as_output().map(|c| {
+//                     self.annotated_entry(i, c.id(), assets)
+//                 })
+//             })
+//             .collect::<Vec<_>>(),
+//         })
+//     }
+
+//     fn find_known_value(&self, entry_index: usize) -> Option<ClearValue> {
+//         self.known_entries
+//             .iter()
+//             .find(|&(i, _)| *i == entry_index)
+//             .map(|(_, value)| *value)
+//     }
+
+//     fn annotated_entry(
+//         &self,
+//         entry_index: usize,
+//         cid: ContractID,
+//         assets: &[AssetRecord],
+//     ) -> JsonValue {
+//         json!({
+//             "id": &util::to_json_value(&cid),
+//             "value": self.find_known_value(entry_index).map(|value| {
+//                 // If found a known entry, find asset alias for its flavor.
+//                 let maybe_alias = assets
+//                     .iter()
+//                     .find(|&asset| asset.flavor() == value.flv)
+//                     .map(|x| x.alias.clone());
+//                 json!({
+//                     "qty": value.qty,
+//                     "flv": &util::to_json_value(&value.flv),
+//                     "alias": maybe_alias
+//                 })
+//             })
+//         })
+//     }
+// }
+
+impl AsRef<ClearValue> for Utxo {
+    fn as_ref(&self) -> &ClearValue {
+        &self.receiver.value
+    }
+}
+
+impl Utxo {
+    /// Convert utxo to a Contract instance
+    pub fn contract(&self) -> Contract {
+        self.receiver.contract(self.anchor)
+    }
+
+    /// Preserves Predicate as ::Key, not as ::Opaque
+    pub fn contract_witness(&self) -> Contract {
+        ReceiverWitness {
+            sequence: self.sequence,
+            receiver: self.receiver.clone(),
+        }
+        .contract(self.anchor)
+    }
+    /// Returns the UTXO ID
+    pub fn contract_id(&self) -> ContractID {
+        self.contract().id()
+    }
+
+    pub fn value(&self) -> ClearValue {
+        self.receiver.value
+    }
+
+    pub fn outgoing(self) -> UtxoWithStatus {
+        UtxoWithStatus {
+            status: UtxoStatus::Outgoing,
+            utxo: self,
+        }
+    }
+
+    pub fn incoming(self) -> UtxoWithStatus {
+        UtxoWithStatus {
+            status: UtxoStatus::Incoming,
+            utxo: self,
+        }
+    }
+
+    pub fn received(self) -> UtxoWithStatus {
+        UtxoWithStatus {
+            status: UtxoStatus::Received,
+            utxo: self,
+        }
+    }
+}
+
+impl UtxoWithStatus {
+    pub fn value(&self) -> ClearValue {
+        self.any_utxo().value()
+    }
+
+    /// Convert utxo to a Contract instance
+    pub fn contract(&self) -> Contract {
+        self.any_utxo().contract()
+    }
+
+    /// Returns the UTXO ID
+    pub fn contract_id(&self) -> ContractID {
+        self.any_utxo().contract_id()
+    }
+
+    pub fn mark_as_spent(&mut self) {
+        self.status = UtxoStatus::Spent;
+    }
+
+    pub fn mark_incoming_as_received(&mut self) {
+        match self.status {
+            UtxoStatus::Incoming => {
+                self.status = UtxoStatus::Received;
+            }
+            UtxoStatus::Received => {}
+            UtxoStatus::Spent => {}
+            UtxoStatus::Outgoing => {}
+        }
+    }
+
+    pub fn into_utxo(self) -> Utxo {
+        self.utxo
+    }
+
+    pub fn as_mut_utxo(&mut self) -> &mut Utxo {
+        &mut self.utxo
+    }
+
+    pub fn any_utxo(&self) -> &Utxo {
+        &self.utxo
+    }
+
+    /// A utxo that belongs to us, even if not spendable yet.
+    pub fn our_utxo(&self) -> Option<&Utxo> {
+        match self.status {
+            UtxoStatus::Incoming => Some(&self.utxo),
+            UtxoStatus::Received => Some(&self.utxo),
+            UtxoStatus::Spent => Some(&self.utxo),
+            UtxoStatus::Outgoing => None,
+        }
+    }
+
+    /// A utxo that belongs to us, which is also safe to spend.
+    pub fn spendable_utxo(&self) -> Option<&Utxo> {
+        match self.status {
+            UtxoStatus::Incoming => None,
+            UtxoStatus::Received => Some(&self.utxo),
+            UtxoStatus::Spent => None,
+            UtxoStatus::Outgoing => None,
+        }
+    }
+
+    /// A utxo that we know about, but it's not ours.
+    pub fn outgoing_utxo(&self) -> Option<&Utxo> {
+        match self.status {
+            UtxoStatus::Incoming => None,
+            UtxoStatus::Received => None,
+            UtxoStatus::Spent => None,
+            UtxoStatus::Outgoing => Some(&self.utxo),
+        }
+    }
+}
 

--- a/node/src/wallet.rs
+++ b/node/src/wallet.rs
@@ -14,7 +14,7 @@ use musig::{Multisignature, VerificationKey};
 use blockchain::utreexo;
 use blockchain::{BlockTx, BlockchainState};
 use zkvm::{
-    self, Anchor, ClearValue, Contract, ContractID, PortableItem, Predicate, Program, TxLog, Value,
+    self, Anchor, ClearValue, Contract, ContractID, PortableItem, Predicate, Program, TxLog,
     VerifiedTx,
 };
 

--- a/token/Cargo.toml
+++ b/token/Cargo.toml
@@ -23,3 +23,9 @@ path = "../spacesuit"
 
 [dependencies.zkvm]
 path = "../zkvm"
+
+[dependencies.keytree]
+path = "../keytree"
+
+[dependencies.musig]
+path = "../musig"

--- a/token/src/derivation.rs
+++ b/token/src/derivation.rs
@@ -1,0 +1,60 @@
+use curve25519_dalek::scalar::Scalar;
+use keytree::{Xprv, Xpub};
+use merlin::Transcript;
+use musig::VerificationKey;
+use zkvm::TranscriptProtocol;
+
+use super::Token;
+
+/// Extension trait for Xprv to derive issuing keys based on the asset alias.
+pub trait XprvDerivation {
+    /// Derives a key for a given asset alias.
+    fn issuing_key(&self, alias: &str) -> Scalar;
+}
+
+impl XprvDerivation for Xprv {
+    fn issuing_key(&self, alias: &str) -> Scalar {
+        self.derive_key(|t| t.append_message(b"token.alias", alias.as_bytes()))
+    }
+}
+
+/// Extension trait for Xprv to derive keys based on sequence number.
+pub trait XpubDerivation {
+    /// Derives a key for a given asset alias.
+    fn issuing_key(&self, alias: &str) -> VerificationKey;
+
+    /// Derives an Address for a given sequence number.
+    fn derive_token(&self, alias: &str) -> Token;
+
+    /// Derives blinding factors for the given value and sequence number.
+    /// Q: Why deterministic derivation?
+    /// A: Blinding factors are high-entropy, so loss of such data is fatal.
+    ///    While loss of low-entropy metadata such as qty and flavor is recoverable
+    ///    from multiple other systems (analytics, counter-parties), or even by bruteforce search.
+    fn value_blinding_factor(&self, alias: &str, qty: u64) -> Scalar;
+}
+
+impl XpubDerivation for Xpub {
+    fn issuing_key(&self, alias: &str) -> VerificationKey {
+        self.derive_key(|t| t.append_message(b"token.alias", alias.as_bytes()))
+    }
+
+    fn derive_token(&self, alias: &str) -> Token {
+        let key = self.issuing_key(alias);
+        Token::new(
+            zkvm::Predicate::Opaque(*key.as_point()),
+            alias.as_bytes().to_vec(),
+        )
+    }
+
+    fn value_blinding_factor(&self, alias: &str, qty: u64) -> Scalar {
+        // Blinding factors are deterministically derived in order to avoid
+        // having to backup secret material.
+        // It can be always re-created from the single root xpub.
+        let mut t = Transcript::new(b"ZkVM.token.blinding");
+        t.append_message(b"xpub", &self.to_bytes());
+        t.append_message(b"alias", alias.as_bytes());
+        t.append_u64(b"qty", qty);
+        t.challenge_scalar(b"qty_blinding")
+    }
+}

--- a/token/src/lib.rs
+++ b/token/src/lib.rs
@@ -1,6 +1,8 @@
 #![deny(missing_docs)]
 //! Token API for ZkVM
 
+mod derivation;
 mod token;
 
 pub use self::token::Token;
+pub use derivation::{XprvDerivation, XpubDerivation};

--- a/token/src/token.rs
+++ b/token/src/token.rs
@@ -53,6 +53,9 @@ impl Token {
 
     /// Adds instructions to a program to retire a given UTXO.
     /// TBD: accept a qty/Token pairing to retire.
+    ///
+    /// DEPRECATED!
+    ///
     pub fn retire<'a>(program: &'a mut Program, prev_output: Contract) -> &'a mut Program {
         program.push(prev_output).input().signtx().retire()
     }

--- a/token/src/token.rs
+++ b/token/src/token.rs
@@ -3,7 +3,7 @@ use zkvm::{Commitment, Contract, Predicate, Program, String, Value};
 
 /// Represents a ZkVM Token with unique flavor and embedded
 /// metadata protected by a user-supplied Predicate.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct Token {
     issuance_predicate: Predicate,
     metadata: Vec<u8>,

--- a/zkvm/src/contract.rs
+++ b/zkvm/src/contract.rs
@@ -1,3 +1,5 @@
+use core::convert::TryFrom;
+use core::convert::TryInto;
 use serde::{Deserialize, Serialize};
 
 use crate::constraints::Commitment;
@@ -7,6 +9,7 @@ use crate::predicate::Predicate;
 use crate::program::ProgramItem;
 use crate::transcript::TranscriptProtocol;
 use crate::types::{String, Value};
+use crate::VMError;
 use merlin::Transcript;
 
 /// Prefix for the string type in the Output Structure
@@ -222,5 +225,250 @@ impl PortableItem {
 impl MerkleItem for ContractID {
     fn commit(&self, t: &mut Transcript) {
         t.append_message(b"contract", self.as_bytes());
+    }
+}
+
+// Parsing contracts
+
+impl TryFrom<PortableItem> for String {
+    type Error = VMError;
+
+    fn try_from(value: PortableItem) -> Result<Self, Self::Error> {
+        match value {
+            PortableItem::String(x) => Ok(x),
+            _ => Err(VMError::TypeNotString)
+        }
+    }
+}
+
+impl TryFrom<PortableItem> for Value {
+    type Error = VMError;
+
+    fn try_from(value: PortableItem) -> Result<Self, Self::Error> {
+        match value {
+            PortableItem::Value(x) => Ok(x),
+            _ => Err(VMError::TypeNotValue)
+        }
+    }
+}
+
+impl TryFrom<PortableItem> for ProgramItem {
+    type Error = VMError;
+
+    fn try_from(value: PortableItem) -> Result<Self, Self::Error> {
+        match value {
+            PortableItem::Program(x) => Ok(x),
+            _ => Err(VMError::TypeNotProgram)
+        }
+    }
+}
+
+
+impl<'a> TryFrom<&'a PortableItem> for &'a String {
+    type Error = VMError;
+
+    fn try_from(value: &'a PortableItem) -> Result<Self, Self::Error> {
+        match value {
+            PortableItem::String(x) => Ok(x),
+            _ => Err(VMError::TypeNotString)
+        }
+    }
+}
+
+impl<'a> TryFrom<&'a PortableItem> for &'a Value {
+    type Error = VMError;
+
+    fn try_from(value: &'a PortableItem) -> Result<Self, Self::Error> {
+        match value {
+            PortableItem::Value(x) => Ok(x),
+            _ => Err(VMError::TypeNotValue)
+        }
+    }
+}
+
+impl<'a> TryFrom<&'a PortableItem> for &'a ProgramItem {
+    type Error = VMError;
+
+    fn try_from(value: &'a PortableItem) -> Result<Self, Self::Error> {
+        match value {
+            PortableItem::Program(x) => Ok(x),
+            _ => Err(VMError::TypeNotProgram)
+        }
+    }
+}
+
+
+impl Contract {
+
+    /// Extracts a single item from the contract's payload with a given type.
+    pub fn extract<'a, T1>(&'a self) -> Option<T1> 
+    where
+        T1: TryFrom<&'a PortableItem>
+    {
+        if self.payload.len() != 1 {
+            return None;
+        }
+        T1::try_from(self.payload.get(0)?).ok()
+    }
+
+    /// Extracts two payload items with the given types.
+    pub fn extract2<'a, T1, T2>(&'a self) -> Option<(T1, T2)> 
+    where
+        T1: TryFrom<&'a PortableItem>,
+        T2: TryFrom<&'a PortableItem>
+    {
+        if self.payload.len() != 2 {
+            return None;
+        }
+        Some(
+            (
+                T1::try_from(self.payload.get(0)?).ok()?,
+                T2::try_from(self.payload.get(1)?).ok()?
+            )
+        )
+    }
+
+    /// Extracts three payload items with the given types.
+    pub fn extract3<'a, T1, T2, T3>(&'a self) -> Option<(T1, T2, T3)> 
+    where
+        T1: TryFrom<&'a PortableItem>,
+        T2: TryFrom<&'a PortableItem>,
+        T3: TryFrom<&'a PortableItem>
+    {
+        if self.payload.len() != 3 {
+            return None;
+        }
+        Some(
+            (
+                T1::try_from(self.payload.get(0)?).ok()?,
+                T2::try_from(self.payload.get(1)?).ok()?,
+                T3::try_from(self.payload.get(2)?).ok()?
+            )
+        )
+    }
+
+    /// Extracts four payload items with the given types.
+    pub fn extract4<'a, T1, T2, T3, T4>(&'a self) -> Option<(T1, T2, T3, T4)> 
+    where
+        T1: TryFrom<&'a PortableItem>,
+        T2: TryFrom<&'a PortableItem>,
+        T3: TryFrom<&'a PortableItem>,
+        T4: TryFrom<&'a PortableItem>
+    {
+        if self.payload.len() != 4 {
+            return None;
+        }
+        Some(
+            (
+                T1::try_from(self.payload.get(0)?).ok()?,
+                T2::try_from(self.payload.get(1)?).ok()?,
+                T3::try_from(self.payload.get(2)?).ok()?,
+                T4::try_from(self.payload.get(3)?).ok()?
+            )
+        )
+    }
+
+    /// Extracts five payload items with the given types.
+    pub fn extract5<'a, T1, T2, T3, T4, T5>(&'a self) -> Option<(T1, T2, T3, T4, T5)> 
+    where
+        T1: TryFrom<&'a PortableItem>,
+        T2: TryFrom<&'a PortableItem>,
+        T3: TryFrom<&'a PortableItem>,
+        T4: TryFrom<&'a PortableItem>,
+        T5: TryFrom<&'a PortableItem>
+    {
+        if self.payload.len() != 5 {
+            return None;
+        }
+        Some(
+            (
+                T1::try_from(self.payload.get(0)?).ok()?,
+                T2::try_from(self.payload.get(1)?).ok()?,
+                T3::try_from(self.payload.get(2)?).ok()?,
+                T4::try_from(self.payload.get(3)?).ok()?,
+                T5::try_from(self.payload.get(4)?).ok()?
+            )
+        )
+    }
+
+    /// Extracts six payload items with the given types.
+    pub fn extract6<'a, T1, T2, T3, T4, T5, T6>(&'a self) -> Option<(T1, T2, T3, T4, T5, T6)> 
+    where
+        T1: TryFrom<&'a PortableItem>,
+        T2: TryFrom<&'a PortableItem>,
+        T3: TryFrom<&'a PortableItem>,
+        T4: TryFrom<&'a PortableItem>,
+        T5: TryFrom<&'a PortableItem>,
+        T6: TryFrom<&'a PortableItem>
+    {
+        if self.payload.len() != 6 {
+            return None;
+        }
+        Some(
+            (
+                T1::try_from(self.payload.get(0)?).ok()?,
+                T2::try_from(self.payload.get(1)?).ok()?,
+                T3::try_from(self.payload.get(2)?).ok()?,
+                T4::try_from(self.payload.get(3)?).ok()?,
+                T5::try_from(self.payload.get(4)?).ok()?,
+                T6::try_from(self.payload.get(5)?).ok()?
+            )
+        )
+    }
+
+    /// Extracts seven payload items with the given types.
+    pub fn extract7<'a, T1, T2, T3, T4, T5, T6, T7>(&'a self) -> Option<(T1, T2, T3, T4, T5, T6, T7)> 
+    where
+        T1: TryFrom<&'a PortableItem>,
+        T2: TryFrom<&'a PortableItem>,
+        T3: TryFrom<&'a PortableItem>,
+        T4: TryFrom<&'a PortableItem>,
+        T5: TryFrom<&'a PortableItem>,
+        T6: TryFrom<&'a PortableItem>,
+        T7: TryFrom<&'a PortableItem>
+    {
+        if self.payload.len() != 7 {
+            return None;
+        }
+        Some(
+            (
+                T1::try_from(self.payload.get(0)?).ok()?,
+                T2::try_from(self.payload.get(1)?).ok()?,
+                T3::try_from(self.payload.get(2)?).ok()?,
+                T4::try_from(self.payload.get(3)?).ok()?,
+                T5::try_from(self.payload.get(4)?).ok()?,
+                T6::try_from(self.payload.get(5)?).ok()?,
+                T7::try_from(self.payload.get(6)?).ok()?,
+            )
+        )
+    }
+
+    /// Extracts eight payload items with the given types.
+    pub fn extract8<'a, T1, T2, T3, T4, T5, T6, T7, T8>(&'a self) -> Option<(T1, T2, T3, T4, T5, T6, T7, T8)> 
+    where
+        T1: TryFrom<&'a PortableItem>,
+        T2: TryFrom<&'a PortableItem>,
+        T3: TryFrom<&'a PortableItem>,
+        T4: TryFrom<&'a PortableItem>,
+        T5: TryFrom<&'a PortableItem>,
+        T6: TryFrom<&'a PortableItem>,
+        T7: TryFrom<&'a PortableItem>,
+        T8: TryFrom<&'a PortableItem>
+    {
+        if self.payload.len() != 8 {
+            return None;
+        }
+        Some(
+            (
+                T1::try_from(self.payload.get(0)?).ok()?,
+                T2::try_from(self.payload.get(1)?).ok()?,
+                T3::try_from(self.payload.get(2)?).ok()?,
+                T4::try_from(self.payload.get(3)?).ok()?,
+                T5::try_from(self.payload.get(4)?).ok()?,
+                T6::try_from(self.payload.get(5)?).ok()?,
+                T7::try_from(self.payload.get(6)?).ok()?,
+                T8::try_from(self.payload.get(7)?).ok()?,
+            )
+        )
     }
 }

--- a/zkvm/src/contract.rs
+++ b/zkvm/src/contract.rs
@@ -1,5 +1,4 @@
 use core::convert::TryFrom;
-use core::convert::TryInto;
 use serde::{Deserialize, Serialize};
 
 use crate::constraints::Commitment;
@@ -236,7 +235,7 @@ impl TryFrom<PortableItem> for String {
     fn try_from(value: PortableItem) -> Result<Self, Self::Error> {
         match value {
             PortableItem::String(x) => Ok(x),
-            _ => Err(VMError::TypeNotString)
+            _ => Err(VMError::TypeNotString),
         }
     }
 }
@@ -247,7 +246,7 @@ impl TryFrom<PortableItem> for Value {
     fn try_from(value: PortableItem) -> Result<Self, Self::Error> {
         match value {
             PortableItem::Value(x) => Ok(x),
-            _ => Err(VMError::TypeNotValue)
+            _ => Err(VMError::TypeNotValue),
         }
     }
 }
@@ -258,11 +257,10 @@ impl TryFrom<PortableItem> for ProgramItem {
     fn try_from(value: PortableItem) -> Result<Self, Self::Error> {
         match value {
             PortableItem::Program(x) => Ok(x),
-            _ => Err(VMError::TypeNotProgram)
+            _ => Err(VMError::TypeNotProgram),
         }
     }
 }
-
 
 impl<'a> TryFrom<&'a PortableItem> for &'a String {
     type Error = VMError;
@@ -270,7 +268,7 @@ impl<'a> TryFrom<&'a PortableItem> for &'a String {
     fn try_from(value: &'a PortableItem) -> Result<Self, Self::Error> {
         match value {
             PortableItem::String(x) => Ok(x),
-            _ => Err(VMError::TypeNotString)
+            _ => Err(VMError::TypeNotString),
         }
     }
 }
@@ -281,7 +279,7 @@ impl<'a> TryFrom<&'a PortableItem> for &'a Value {
     fn try_from(value: &'a PortableItem) -> Result<Self, Self::Error> {
         match value {
             PortableItem::Value(x) => Ok(x),
-            _ => Err(VMError::TypeNotValue)
+            _ => Err(VMError::TypeNotValue),
         }
     }
 }
@@ -292,18 +290,16 @@ impl<'a> TryFrom<&'a PortableItem> for &'a ProgramItem {
     fn try_from(value: &'a PortableItem) -> Result<Self, Self::Error> {
         match value {
             PortableItem::Program(x) => Ok(x),
-            _ => Err(VMError::TypeNotProgram)
+            _ => Err(VMError::TypeNotProgram),
         }
     }
 }
 
-
 impl Contract {
-
     /// Extracts a single item from the contract's payload with a given type.
-    pub fn extract<'a, T1>(&'a self) -> Option<T1> 
+    pub fn extract<'a, T1>(&'a self) -> Option<T1>
     where
-        T1: TryFrom<&'a PortableItem>
+        T1: TryFrom<&'a PortableItem>,
     {
         if self.payload.len() != 1 {
             return None;
@@ -312,112 +308,79 @@ impl Contract {
     }
 
     /// Extracts two payload items with the given types.
-    pub fn extract2<'a, T1, T2>(&'a self) -> Option<(T1, T2)> 
+    pub fn extract2<'a, T1, T2>(&'a self) -> Option<(T1, T2)>
     where
         T1: TryFrom<&'a PortableItem>,
-        T2: TryFrom<&'a PortableItem>
+        T2: TryFrom<&'a PortableItem>,
     {
         if self.payload.len() != 2 {
             return None;
         }
-        Some(
-            (
-                T1::try_from(self.payload.get(0)?).ok()?,
-                T2::try_from(self.payload.get(1)?).ok()?
-            )
-        )
+        Some((
+            T1::try_from(self.payload.get(0)?).ok()?,
+            T2::try_from(self.payload.get(1)?).ok()?,
+        ))
     }
 
     /// Extracts three payload items with the given types.
-    pub fn extract3<'a, T1, T2, T3>(&'a self) -> Option<(T1, T2, T3)> 
-    where
-        T1: TryFrom<&'a PortableItem>,
-        T2: TryFrom<&'a PortableItem>,
-        T3: TryFrom<&'a PortableItem>
-    {
-        if self.payload.len() != 3 {
-            return None;
-        }
-        Some(
-            (
-                T1::try_from(self.payload.get(0)?).ok()?,
-                T2::try_from(self.payload.get(1)?).ok()?,
-                T3::try_from(self.payload.get(2)?).ok()?
-            )
-        )
-    }
-
-    /// Extracts four payload items with the given types.
-    pub fn extract4<'a, T1, T2, T3, T4>(&'a self) -> Option<(T1, T2, T3, T4)> 
+    pub fn extract3<'a, T1, T2, T3>(&'a self) -> Option<(T1, T2, T3)>
     where
         T1: TryFrom<&'a PortableItem>,
         T2: TryFrom<&'a PortableItem>,
         T3: TryFrom<&'a PortableItem>,
-        T4: TryFrom<&'a PortableItem>
     {
-        if self.payload.len() != 4 {
+        if self.payload.len() != 3 {
             return None;
         }
-        Some(
-            (
-                T1::try_from(self.payload.get(0)?).ok()?,
-                T2::try_from(self.payload.get(1)?).ok()?,
-                T3::try_from(self.payload.get(2)?).ok()?,
-                T4::try_from(self.payload.get(3)?).ok()?
-            )
-        )
+        Some((
+            T1::try_from(self.payload.get(0)?).ok()?,
+            T2::try_from(self.payload.get(1)?).ok()?,
+            T3::try_from(self.payload.get(2)?).ok()?,
+        ))
     }
 
-    /// Extracts five payload items with the given types.
-    pub fn extract5<'a, T1, T2, T3, T4, T5>(&'a self) -> Option<(T1, T2, T3, T4, T5)> 
+    /// Extracts four payload items with the given types.
+    pub fn extract4<'a, T1, T2, T3, T4>(&'a self) -> Option<(T1, T2, T3, T4)>
     where
         T1: TryFrom<&'a PortableItem>,
         T2: TryFrom<&'a PortableItem>,
         T3: TryFrom<&'a PortableItem>,
         T4: TryFrom<&'a PortableItem>,
-        T5: TryFrom<&'a PortableItem>
     {
-        if self.payload.len() != 5 {
+        if self.payload.len() != 4 {
             return None;
         }
-        Some(
-            (
-                T1::try_from(self.payload.get(0)?).ok()?,
-                T2::try_from(self.payload.get(1)?).ok()?,
-                T3::try_from(self.payload.get(2)?).ok()?,
-                T4::try_from(self.payload.get(3)?).ok()?,
-                T5::try_from(self.payload.get(4)?).ok()?
-            )
-        )
+        Some((
+            T1::try_from(self.payload.get(0)?).ok()?,
+            T2::try_from(self.payload.get(1)?).ok()?,
+            T3::try_from(self.payload.get(2)?).ok()?,
+            T4::try_from(self.payload.get(3)?).ok()?,
+        ))
     }
 
-    /// Extracts six payload items with the given types.
-    pub fn extract6<'a, T1, T2, T3, T4, T5, T6>(&'a self) -> Option<(T1, T2, T3, T4, T5, T6)> 
+    /// Extracts five payload items with the given types.
+    pub fn extract5<'a, T1, T2, T3, T4, T5>(&'a self) -> Option<(T1, T2, T3, T4, T5)>
     where
         T1: TryFrom<&'a PortableItem>,
         T2: TryFrom<&'a PortableItem>,
         T3: TryFrom<&'a PortableItem>,
         T4: TryFrom<&'a PortableItem>,
         T5: TryFrom<&'a PortableItem>,
-        T6: TryFrom<&'a PortableItem>
     {
-        if self.payload.len() != 6 {
+        if self.payload.len() != 5 {
             return None;
         }
-        Some(
-            (
-                T1::try_from(self.payload.get(0)?).ok()?,
-                T2::try_from(self.payload.get(1)?).ok()?,
-                T3::try_from(self.payload.get(2)?).ok()?,
-                T4::try_from(self.payload.get(3)?).ok()?,
-                T5::try_from(self.payload.get(4)?).ok()?,
-                T6::try_from(self.payload.get(5)?).ok()?
-            )
-        )
+        Some((
+            T1::try_from(self.payload.get(0)?).ok()?,
+            T2::try_from(self.payload.get(1)?).ok()?,
+            T3::try_from(self.payload.get(2)?).ok()?,
+            T4::try_from(self.payload.get(3)?).ok()?,
+            T5::try_from(self.payload.get(4)?).ok()?,
+        ))
     }
 
-    /// Extracts seven payload items with the given types.
-    pub fn extract7<'a, T1, T2, T3, T4, T5, T6, T7>(&'a self) -> Option<(T1, T2, T3, T4, T5, T6, T7)> 
+    /// Extracts six payload items with the given types.
+    pub fn extract6<'a, T1, T2, T3, T4, T5, T6>(&'a self) -> Option<(T1, T2, T3, T4, T5, T6)>
     where
         T1: TryFrom<&'a PortableItem>,
         T2: TryFrom<&'a PortableItem>,
@@ -425,26 +388,24 @@ impl Contract {
         T4: TryFrom<&'a PortableItem>,
         T5: TryFrom<&'a PortableItem>,
         T6: TryFrom<&'a PortableItem>,
-        T7: TryFrom<&'a PortableItem>
     {
-        if self.payload.len() != 7 {
+        if self.payload.len() != 6 {
             return None;
         }
-        Some(
-            (
-                T1::try_from(self.payload.get(0)?).ok()?,
-                T2::try_from(self.payload.get(1)?).ok()?,
-                T3::try_from(self.payload.get(2)?).ok()?,
-                T4::try_from(self.payload.get(3)?).ok()?,
-                T5::try_from(self.payload.get(4)?).ok()?,
-                T6::try_from(self.payload.get(5)?).ok()?,
-                T7::try_from(self.payload.get(6)?).ok()?,
-            )
-        )
+        Some((
+            T1::try_from(self.payload.get(0)?).ok()?,
+            T2::try_from(self.payload.get(1)?).ok()?,
+            T3::try_from(self.payload.get(2)?).ok()?,
+            T4::try_from(self.payload.get(3)?).ok()?,
+            T5::try_from(self.payload.get(4)?).ok()?,
+            T6::try_from(self.payload.get(5)?).ok()?,
+        ))
     }
 
-    /// Extracts eight payload items with the given types.
-    pub fn extract8<'a, T1, T2, T3, T4, T5, T6, T7, T8>(&'a self) -> Option<(T1, T2, T3, T4, T5, T6, T7, T8)> 
+    /// Extracts seven payload items with the given types.
+    pub fn extract7<'a, T1, T2, T3, T4, T5, T6, T7>(
+        &'a self,
+    ) -> Option<(T1, T2, T3, T4, T5, T6, T7)>
     where
         T1: TryFrom<&'a PortableItem>,
         T2: TryFrom<&'a PortableItem>,
@@ -453,22 +414,47 @@ impl Contract {
         T5: TryFrom<&'a PortableItem>,
         T6: TryFrom<&'a PortableItem>,
         T7: TryFrom<&'a PortableItem>,
-        T8: TryFrom<&'a PortableItem>
+    {
+        if self.payload.len() != 7 {
+            return None;
+        }
+        Some((
+            T1::try_from(self.payload.get(0)?).ok()?,
+            T2::try_from(self.payload.get(1)?).ok()?,
+            T3::try_from(self.payload.get(2)?).ok()?,
+            T4::try_from(self.payload.get(3)?).ok()?,
+            T5::try_from(self.payload.get(4)?).ok()?,
+            T6::try_from(self.payload.get(5)?).ok()?,
+            T7::try_from(self.payload.get(6)?).ok()?,
+        ))
+    }
+
+    /// Extracts eight payload items with the given types.
+    pub fn extract8<'a, T1, T2, T3, T4, T5, T6, T7, T8>(
+        &'a self,
+    ) -> Option<(T1, T2, T3, T4, T5, T6, T7, T8)>
+    where
+        T1: TryFrom<&'a PortableItem>,
+        T2: TryFrom<&'a PortableItem>,
+        T3: TryFrom<&'a PortableItem>,
+        T4: TryFrom<&'a PortableItem>,
+        T5: TryFrom<&'a PortableItem>,
+        T6: TryFrom<&'a PortableItem>,
+        T7: TryFrom<&'a PortableItem>,
+        T8: TryFrom<&'a PortableItem>,
     {
         if self.payload.len() != 8 {
             return None;
         }
-        Some(
-            (
-                T1::try_from(self.payload.get(0)?).ok()?,
-                T2::try_from(self.payload.get(1)?).ok()?,
-                T3::try_from(self.payload.get(2)?).ok()?,
-                T4::try_from(self.payload.get(3)?).ok()?,
-                T5::try_from(self.payload.get(4)?).ok()?,
-                T6::try_from(self.payload.get(5)?).ok()?,
-                T7::try_from(self.payload.get(6)?).ok()?,
-                T8::try_from(self.payload.get(7)?).ok()?,
-            )
-        )
+        Some((
+            T1::try_from(self.payload.get(0)?).ok()?,
+            T2::try_from(self.payload.get(1)?).ok()?,
+            T3::try_from(self.payload.get(2)?).ok()?,
+            T4::try_from(self.payload.get(3)?).ok()?,
+            T5::try_from(self.payload.get(4)?).ok()?,
+            T6::try_from(self.payload.get(5)?).ok()?,
+            T7::try_from(self.payload.get(6)?).ok()?,
+            T8::try_from(self.payload.get(7)?).ok()?,
+        ))
     }
 }

--- a/zkvm/src/errors.rs
+++ b/zkvm/src/errors.rs
@@ -86,10 +86,6 @@ pub enum VMError {
     #[error("Item is not a LE32 integer.")]
     TypeNotU32,
 
-    /// This error occurs when an instruction requires a program item.
-    #[error("Item is not a program item.")]
-    TypeNotProgramItem,
-
     /// This error occurs when an instruction expects a predicate tree type.
     #[error("Item is not a predicate tree.")]
     TypeNotPredicateTree,

--- a/zkvm/src/predicate.rs
+++ b/zkvm/src/predicate.rs
@@ -19,7 +19,7 @@ use crate::program::{Program, ProgramItem};
 use crate::transcript::TranscriptProtocol;
 
 /// Represents a ZkVM predicate with its optional witness data.
-#[derive(Clone, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Deserialize, Serialize)]
 pub enum Predicate {
     /// Verifier's view on the predicate in a compressed form to defer decompression cost.
     Opaque(CompressedRistretto),
@@ -323,6 +323,20 @@ impl MerkleItem for PredicateLeaf {
             PredicateLeaf::Program(prog) => prog.commit(t),
             PredicateLeaf::Blinding(bytes) => t.append_message(b"blinding", &bytes.clone()),
         }
+    }
+}
+
+impl PartialEq for Predicate {
+    fn eq(&self, other: &Self) -> bool {
+        self.to_point().eq(&other.to_point())
+    }
+}
+
+impl Eq for Predicate {}
+
+impl core::hash::Hash for Predicate {
+    fn hash<H: core::hash::Hasher>(&self, state: &mut H) {
+        self.to_point().hash(state)
     }
 }
 

--- a/zkvm/src/tx.rs
+++ b/zkvm/src/tx.rs
@@ -308,6 +308,14 @@ impl TxLog {
             _ => None,
         })
     }
+
+    /// Iterator over all data entries
+    pub fn data_entries<'a>(&'a self) -> impl Iterator<Item = &'a [u8]> {
+        self.0.iter().filter_map(|entry| match entry {
+            TxEntry::Data(buf) => Some(&buf[..]),
+            _ => None,
+        })
+    }
 }
 
 impl From<Vec<TxEntry>> for TxLog {

--- a/zkvm/src/types.rs
+++ b/zkvm/src/types.rs
@@ -135,7 +135,7 @@ impl Item {
     pub fn to_program(self) -> Result<ProgramItem, VMError> {
         match self {
             Item::Program(x) => Ok(x),
-            _ => Err(VMError::TypeNotProgramItem),
+            _ => Err(VMError::TypeNotProgram),
         }
     }
 


### PR DESCRIPTION
This adds wallet logic. So we can manage spendable utxos.

## Data model

The entire wallet data is a list of unexpired receivers, annotated txs and spendable utxos with different states.

For simplicity, we'll store the entire thing in a single file and load it as a whole. Later, we'll probably need to keep it in a sqlite or at least separate files: for pending txs, for spendable utxos, for archived txs, etc. Make sure the storage is completely separate from the blockchain data.

## TODO

- [x] init new blockchain with a new account "Main" that gets seed utxos.
- [x] review block/tx processing logic to differentiate between detecting unconfirmed txs and confirmed txs
- [x] make the wallet storable per config options
- [x] issuance API




