### PR TITLE
demo: fix formatting of schema file causing diff

### DIFF
--- a/demo/src/schema.rs
+++ b/demo/src/schema.rs
@@ -34,4 +34,9 @@ table! {
     }
 }
 
-allow_tables_to_appear_in_same_query!(account_records, asset_records, block_records, user_records,);
+allow_tables_to_appear_in_same_query!(
+    account_records,
+    asset_records,
+    block_records,
+    user_records,
+);


### PR DESCRIPTION
### What
Fix the formatting of a schema file that gets fixed up whenever running
diesel database reset.

### Why
Every time diesel database reset is executed it (or something) fixes the
formatting of schema.rs. It causes a diff to appear which is
inconvenient.