### PR TITLE
demo: fix rendering of account (node/show template)

### DIFF
--- a/demo/src/handlers.rs
+++ b/demo/src/handlers.rs
@@ -286,6 +286,7 @@ fn nodes_show(
     let context = json!({
         "sidebar": sidebar.json,
         "wallet": wallet_pending.to_json(),
+        "wallet_xpub": util::to_json_value(&wallet_pending.xprv.to_xpub()),
         "balances": balances,
         "others": others_accs,
         "pending_txs": pending_txs.into_iter().map(|atx| {

--- a/demo/templates/nodes/show.html.tera
+++ b/demo/templates/nodes/show.html.tera
@@ -16,9 +16,9 @@
           <em>Use this Wallet ID to receive payments from other people.</em>
         </td>
       </tr>
-      <tr><th>Sequence&nbsp;#</th><td>{{wallet.account.sequence}}</td></tr>
+      <tr><th>Sequence&nbsp;#</th><td>{{wallet.sequence}}</td></tr>
       <tr><th>Xprv</th><td><code>{{wallet.xprv}}</code></td></tr>
-      <tr><th>Xpub</th><td><code>{{wallet.account.xpub}}</code></td></tr>
+      <tr><th>Xpub</th><td><code>{{wallet_xpub}}</code></td></tr>
     </tbody>
   </table>
 


### PR DESCRIPTION
### What
Change where the account sequence and xpub are retrieved from on the node/show page.

### Why
The account package was refactored in dffffb2fe0bd85467479e9e8422d63cc973e9a14 and that resulted in the sequence moving from the account object to the wallet object, and the xpub is no longer stored in an object that has been serialized.

Updating where the sequence should come from is trivial.

Updating where the xpub could be done a couple of ways. We could expand the JSON serialized wallet to include it, but that requires changing the account package and the xpub would only be added to the struct for the demo, so instead I added it to the context for rendering the template separately to the wallet. I could see reasons to go both ways though.

Fix #476