### PR TITLE
node: separate signing from building

### DIFF
--- a/zkvm/src/tx.rs
+++ b/zkvm/src/tx.rs
@@ -57,7 +57,7 @@ pub struct TxHeader {
 }
 
 /// Instance of a transaction that is not signed yet.
-#[derive(Clone)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct UnsignedTx {
     /// Header metadata
     pub header: TxHeader,

--- a/zkvm/src/vm.rs
+++ b/zkvm/src/vm.rs
@@ -530,7 +530,7 @@ where
         Ok(())
     }
 
-    // _value qty_ **fee** → ø
+    // _qty_ **fee** → _widevalue_
     fn fee(&mut self) -> Result<(), VMError> {
         let fee = self.pop_item()?.to_string()?.to_u32()? as u64;
         let fee_scalar = Scalar::from(fee);


### PR DESCRIPTION
Adds intermediate type `BuiltTx` that contains all tx data, utreexo proofs, and signing instructions (derivation sequences and aliases). Then, the `BuiltTx::sign` method takes an Xprv, derives all the keys according to the instructions and returns a fully signed `BlockTx`, that can be published.

Closes #485