### PR TITLE
zkvm: rename CS variable operations

### DIFF
--- a/demo/src/account.rs
+++ b/demo/src/account.rs
@@ -357,9 +357,9 @@ impl Wallet {
                     zkvm::Predicate::Key(zkvm::VerificationKey::from_secret(&issuance_key));
 
                 p.push(zkvm::Commitment::blinded(payment_receiver.value.qty)) // stack: qty
-                    .var() // stack: qty-var
+                    .commit() // stack: qty-var
                     .push(zkvm::Commitment::unblinded(payment_receiver.value.flv)) // stack: qty-var, flv
-                    .var() // stack: qty-var, flv-var
+                    .commit() // stack: qty-var, flv-var
                     .push(issuance_metadata) // stack: qty-var, flv-var, data
                     .push(issuance_predicate) // stack: qty-var, flv-var, data, flv-pred
                     .issue() // stack: issue-contract

--- a/demo/src/schema.rs
+++ b/demo/src/schema.rs
@@ -34,9 +34,4 @@ table! {
     }
 }
 
-allow_tables_to_appear_in_same_query!(
-    account_records,
-    asset_records,
-    block_records,
-    user_records,
-);
+allow_tables_to_appear_in_same_query!(account_records, asset_records, block_records, user_records,);

--- a/demo/src/schema.rs
+++ b/demo/src/schema.rs
@@ -34,4 +34,9 @@ table! {
     }
 }
 
-allow_tables_to_appear_in_same_query!(account_records, asset_records, block_records, user_records,);
+allow_tables_to_appear_in_same_query!(
+    account_records,
+    asset_records,
+    block_records,
+    user_records,
+);

--- a/token/src/token.rs
+++ b/token/src/token.rs
@@ -31,9 +31,9 @@ impl Token {
     pub fn issue<'a>(&self, program: &'a mut Program, qty: u64) -> &'a mut Program {
         program
             .push(Commitment::blinded(qty)) // stack: qty
-            .var() // stack: qty-var
+            .commit() // stack: qty-var
             .push(Commitment::unblinded(self.flavor())) // stack: qty-var, flv
-            .var() // stack: qty-var, flv-var
+            .commit() // stack: qty-var, flv-var
             .push(String::Opaque(self.metadata.clone())) // stack: qty-var, flv-var, data
             .push(self.issuance_predicate.clone()) // stack: qty-var, flv-var, data, flv-pred
             .issue() // stack: issue-contract

--- a/zkvm/docs/zkvm-spec.md
+++ b/zkvm/docs/zkvm-spec.md
@@ -233,7 +233,7 @@ Each contract contains a hidden field [anchor](#anchor) that makes it globally u
 _Variable_ represents a secret [scalar](#scalar-value) value in the [constraint system](#constraint-system)
 bound to its [Pedersen commitment](#pedersen-commitment).
 
-A [point](#point) that represents a commitment to a secret scalar can be turned into a variable using the [`var`](#var) instruction.
+A [point](#point) that represents a commitment to a secret scalar can be turned into a variable using the [`commit`](#commit) instruction.
 
 A cleartext [scalar](#scalar-value) can be turned into a single-term [expression](#expression-type) using the [`scalar`](#scalar) instruction (which does not allocate a variable). Since we do not need to hide their values, a Variable is not needed to represent the cleartext constant.
 
@@ -380,7 +380,7 @@ where:
 * `f` is a secret blinding factor (scalar),
 * `B` and `B2` are [base points](#base-points).
 
-Pedersen commitments can be used to allocate new [variables](#variable-type) using the [`var`](#var) instruction.
+Pedersen commitments can be used to allocate new [variables](#variable-type) using the [`commit`](#commit) instruction.
 
 Pedersen commitments can be opened using the [`unblind`](#unblind) instruction.
 
@@ -937,7 +937,7 @@ Code | Instruction                | Stack diagram                              |
  |                                |                                            |
  |     [**Constraints**](#constraint-system-instructions)  |                   | 
 0x05 | [`scalar`](#scalar)        |          _scalar_ → _expr_                 | 
-0x06 | [`var`](#var)              |           _point_ → _var_                  | Adds an external variable to [CS](#constraint-system)
+0x06 | [`commit`](#commit)        |           _point_ → _var_                  | Adds an external variable to [CS](#constraint-system)
 0x07 | [`alloc`](#alloc)          |                 ø → _expr_                 | Allocates a low-level variable in [CS](#constraint-system)
 0x08 | [`mintime`](#mintime)      |                 ø → _expr_                 |
 0x09 | [`maxtime`](#maxtime)      |                 ø → _expr_                 |
@@ -1036,9 +1036,9 @@ _a_ **scalar** → _expr_
 
 Fails if `a` is not a valid [scalar](#scalar-value).
 
-#### var
+#### commit
 
-_P_ **var** → _v_
+_P_ **commit** → _v_
 
 1. Pops a [point](#point) `P` from the stack.
 2. Creates a [variable](#variable-type) `v` from a [Pedersen commitment](#pedersen-commitment) `P`.
@@ -1053,7 +1053,7 @@ Fails if `P` is not a valid [point](#point).
 1. Allocates a low-level variable in the [constraint system](#constraint-system) and wraps it in the [expression](#expression-type) with weight 1.
 2. Pushes the resulting expression to the stack.
 
-This is different from [`var`](#var): the variable created by `alloc` is _not_ represented by an individual Pedersen commitment and therefore can be chosen freely when the transaction is constructed.
+This is different from [`commit`](#commit): the variable created by `alloc` is _not_ represented by an individual Pedersen commitment and therefore can be chosen freely when the transaction is constructed.
 
 
 #### mintime

--- a/zkvm/docs/zkvm-spec.md
+++ b/zkvm/docs/zkvm-spec.md
@@ -23,7 +23,7 @@ ZkVM defines a procedural representation for blockchain transactions and the rul
 * [Definitions](#definitions)
     * [LE32](#le32)
     * [LE64](#le64)
-    * [Scalar](#scalar)
+    * [Scalar](#scalar-value)
     * [Point](#point)
     * [Base points](#base-points)
     * [Pedersen commitment](#pedersen-commitment)
@@ -202,7 +202,7 @@ and its constraint system, and therefore cannot be meaningfully ported between t
 
 ### String type
 
-A _string_ is a variable-length byte array used to represent [commitments](#pedersen-commitment), [scalars](#scalar), signatures, and proofs.
+A _string_ is a variable-length byte array used to represent [commitments](#pedersen-commitment), [scalars](#scalar-value), signatures, and proofs.
 
 A string cannot be larger than the entire transaction program and cannot be longer than `2^32-1` bytes (see [LE32](#le32)).
 
@@ -230,12 +230,12 @@ Each contract contains a hidden field [anchor](#anchor) that makes it globally u
 
 ### Variable type
 
-_Variable_ represents a secret [scalar](#scalar) value in the [constraint system](#constraint-system)
+_Variable_ represents a secret [scalar](#scalar-value) value in the [constraint system](#constraint-system)
 bound to its [Pedersen commitment](#pedersen-commitment).
 
 A [point](#point) that represents a commitment to a secret scalar can be turned into a variable using the [`var`](#var) instruction.
 
-A cleartext [scalar](#scalar) can be turned into a single-term [expression](#expression-type) using the [`const`](#const) instruction (which does not allocate a variable). Since we do not need to hide their values, a Variable is not needed to represent the cleartext constant.
+A cleartext [scalar](#scalar-value) can be turned into a single-term [expression](#expression-type) using the [`const`](#const) instruction (which does not allocate a variable). Since we do not need to hide their values, a Variable is not needed to represent the cleartext constant.
 
 Variables can be copied and dropped at will, but cannot be ported across transactions via [outputs](#output-structure).
 
@@ -247,7 +247,7 @@ when these are exposed to the VM (for instance, from [`mul`](#mul)), they have t
 
 ### Expression type
 
-_Expression_ is a linear combination of constraint system variables with cleartext [scalar](#scalar) weights.
+_Expression_ is a linear combination of constraint system variables with cleartext [scalar](#scalar-value) weights.
 
     expr = { (weight0, var0), (weight1, var1), ...  }
 
@@ -261,7 +261,7 @@ Expressions can be [added](#add) and [multiplied](#mul), producing new expressio
 
 ### Constant expression
 
-An [expression](#expression-type) that contains one term with the [scalar](#scalar) weight assigned to the R1CS `1` is considered
+An [expression](#expression-type) that contains one term with the [scalar](#scalar-value) weight assigned to the R1CS `1` is considered
 a _constant expression_:
 
     const_expr = { (weight, 1) }
@@ -331,7 +331,7 @@ A non-negative 64-bit integer encoded using little-endian convention.
 Used to encode [value quantities](#value-type) and [timestamps](#time-bounds).
 
 
-### Scalar
+### Scalar value
 
 A _scalar_ is an integer modulo [Ristretto group](https://ristretto.group) order `|G| = 2^252 + 27742317777372353535851937790883648493`.
 
@@ -366,7 +366,7 @@ and used in [Pedersen commitments](#pedersen-commitment),
 
 ### Pedersen commitment
 
-Pedersen commitment to a secret [scalar](#scalar)
+Pedersen commitment to a secret [scalar](#scalar-value)
 is defined as a point with the following structure:
 
 ```
@@ -387,7 +387,7 @@ Pedersen commitments can be opened using the [`unblind`](#unblind) instruction.
 
 ### Verification key
 
-A _verification key_ `P` is a commitment to a secret [scalar](#scalar) `x` (_signing key_)
+A _verification key_ `P` is a commitment to a secret [scalar](#scalar-value) `x` (_signing key_)
 using the primary [base point](#base-points) `B`: `P = x·B`.
 Verification keys are used to construct [predicates](#predicate) and verify [signatures](#transaction-signature).
 
@@ -461,7 +461,7 @@ Transcript is an instance of the [Merlin](https://doc.dalek.rs/merlin/) construc
 which is itself based on [STROBE](https://strobe.sourceforge.io/) and [Keccak-f](https://keccak.team/keccak.html)
 with 128-bit security parameter.
 
-Transcript is used throughout ZkVM to generate challenge [scalars](#scalar) and commitments.
+Transcript is used throughout ZkVM to generate challenge [scalars](#scalar-value) and commitments.
 
 Transcripts have the following operations, each taking a label for domain separation:
 
@@ -875,13 +875,13 @@ Each deferred operation at index `i` represents a statement:
 0  ==  sum{s[i,j]·P[i,j], for all j}  +  a[i]·B  +  b[i]·B2
 ```
 where:
-1. `{s[i,j],P[i,j]}` is an array of ([scalar](#scalar),[point](#point)) tuples,
-2. `a[i]` is a [scalar](#scalar) weight of a [primary base point](#base-points) `B`,
-3. `b[i]` is a [scalar](#scalar) weight of a [secondary base point](#base-points) `B2`.
+1. `{s[i,j],P[i,j]}` is an array of ([scalar](#scalar-value),[point](#point)) tuples,
+2. `a[i]` is a [scalar](#scalar-value) weight of a [primary base point](#base-points) `B`,
+3. `b[i]` is a [scalar](#scalar-value) weight of a [secondary base point](#base-points) `B2`.
 
 All such statements are combined using the following method:
 
-1. For each statement, a random [scalar](#scalar) `x[i]` is sampled.
+1. For each statement, a random [scalar](#scalar-value) `x[i]` is sampled.
 2. Each weight `s[i,j]` is multiplied by `x[i]` for all weights per statement `i`:
     ```
     z[i,j] = x[i]·s[i,j]
@@ -1030,11 +1030,11 @@ Note: `roll:0` is a no-op, `roll:1` swaps the top two items.
 
 _a_ **const** → _expr_
 
-1. Pops a [scalar](#scalar) `a` from the stack.
+1. Pops a [scalar](#scalar-value) `a` from the stack.
 2. Creates an [expression](#expression-type) `expr` with weight `a` assigned to an R1CS constant `1`.
 3. Pushes `expr` to the stack.
 
-Fails if `a` is not a valid [scalar](#scalar).
+Fails if `a` is not a valid [scalar](#scalar-value).
 
 #### var
 
@@ -1236,13 +1236,13 @@ Fails if `constr` is not a [constraint](#constraint-type).
 
 _V v_ **unblind** → _V_
 
-1. Pops [scalar](#scalar) `v`.
+1. Pops [scalar](#scalar-value) `v`.
 2. Pops [point](#point) `V`.
 3. Verifies the [unblinding proof](#unblinding-proof) for the commitment `V` and scalar `v`, [deferring all point operations](#deferred-point-operations)).
 4. Pushes [point](#point) `V`.
 
 Fails if: 
-* `v` is not a valid [scalar](#scalar), or
+* `v` is not a valid [scalar](#scalar-value), or
 * `V` is not a valid [point](#point), or
 
 

--- a/zkvm/docs/zkvm-spec.md
+++ b/zkvm/docs/zkvm-spec.md
@@ -235,7 +235,7 @@ bound to its [Pedersen commitment](#pedersen-commitment).
 
 A [point](#point) that represents a commitment to a secret scalar can be turned into a variable using the [`var`](#var) instruction.
 
-A cleartext [scalar](#scalar-value) can be turned into a single-term [expression](#expression-type) using the [`const`](#const) instruction (which does not allocate a variable). Since we do not need to hide their values, a Variable is not needed to represent the cleartext constant.
+A cleartext [scalar](#scalar-value) can be turned into a single-term [expression](#expression-type) using the [`scalar`](#scalar) instruction (which does not allocate a variable). Since we do not need to hide their values, a Variable is not needed to represent the cleartext constant.
 
 Variables can be copied and dropped at will, but cannot be ported across transactions via [outputs](#output-structure).
 
@@ -936,7 +936,7 @@ Code | Instruction                | Stack diagram                              |
 0x04 | [`roll:k`](#roll)          |     _x[k] … x[0]_ → _x[k-1] ... x[0] x[k]_ |
  |                                |                                            |
  |     [**Constraints**](#constraint-system-instructions)  |                   | 
-0x05 | [`const`](#var)            |          _scalar_ → _expr_                 | 
+0x05 | [`scalar`](#scalar)        |          _scalar_ → _expr_                 | 
 0x06 | [`var`](#var)              |           _point_ → _var_                  | Adds an external variable to [CS](#constraint-system)
 0x07 | [`alloc`](#alloc)          |                 ø → _expr_                 | Allocates a low-level variable in [CS](#constraint-system)
 0x08 | [`mintime`](#mintime)      |                 ø → _expr_                 |
@@ -1026,9 +1026,9 @@ Note: `roll:0` is a no-op, `roll:1` swaps the top two items.
 
 ### Constraint system instructions
 
-#### const
+#### scalar
 
-_a_ **const** → _expr_
+_a_ **scalar** → _expr_
 
 1. Pops a [scalar](#scalar-value) `a` from the stack.
 2. Creates an [expression](#expression-type) `expr` with weight `a` assigned to an R1CS constant `1`.
@@ -1062,7 +1062,7 @@ This is different from [`var`](#var): the variable created by `alloc` is _not_ r
 
 Pushes an [expression](#expression-type) `expr` corresponding to the [minimum time bound](#time-bounds) of the transaction.
 
-The one-term expression represents time bound as a weight on the R1CS constant `1` (see [`const`](#const)).
+The one-term expression represents time bound as a weight on the R1CS constant `1` (see [`scalar`](#scalar)).
 
 #### maxtime
 
@@ -1070,7 +1070,7 @@ The one-term expression represents time bound as a weight on the R1CS constant `
 
 Pushes an [expression](#expression-type) `expr` corresponding to the [maximum time bound](#time-bounds) of the transaction.
 
-The one-term expression represents time bound as a weight on the R1CS constant `1` (see [`const`](#const)).
+The one-term expression represents time bound as a weight on the R1CS constant `1` (see [`scalar`](#scalar)).
 
 #### expr
 

--- a/zkvm/src/debug.rs
+++ b/zkvm/src/debug.rs
@@ -101,7 +101,7 @@ impl Instruction {
             Instruction::Drop => write!(f, "drop"),
             Instruction::Dup(i) => write!(f, "dup:{}", i),
             Instruction::Roll(i) => write!(f, "roll:{}", i),
-            Instruction::Const => write!(f, "const"),
+            Instruction::Scalar => write!(f, "scalar"),
             Instruction::Var => write!(f, "var"),
             Instruction::Alloc(_) => write!(f, "alloc"),
             Instruction::Mintime => write!(f, "mintime"),

--- a/zkvm/src/debug.rs
+++ b/zkvm/src/debug.rs
@@ -102,7 +102,7 @@ impl Instruction {
             Instruction::Dup(i) => write!(f, "dup:{}", i),
             Instruction::Roll(i) => write!(f, "roll:{}", i),
             Instruction::Scalar => write!(f, "scalar"),
-            Instruction::Var => write!(f, "var"),
+            Instruction::Commit => write!(f, "commit"),
             Instruction::Alloc(_) => write!(f, "alloc"),
             Instruction::Mintime => write!(f, "mintime"),
             Instruction::Maxtime => write!(f, "maxtime"),

--- a/zkvm/src/ops.rs
+++ b/zkvm/src/ops.rs
@@ -49,14 +49,14 @@ pub enum Instruction {
     /// Note: `roll:0` is a no-op, `roll:1` swaps the top two items.
     Roll(usize),
 
-    /// _a_ **const** → _expr_
+    /// _a_ **scalar** → _expr_
     ///
     /// 1. Pops a _scalar_ `a` from the stack.
     /// 2. Creates an _expression_ `expr` with weight `a` assigned to an R1CS constant `1`.
     /// 3. Pushes `expr` to the stack.
     ///
     /// Fails if `a` is not a valid _scalar_.
-    Const,
+    Scalar,
 
     /// _P_ **var** → _v_
     ///
@@ -79,14 +79,14 @@ pub enum Instruction {
     ///
     /// Pushes an _expression_ `expr` corresponding to the _minimum time bound_ of the transaction.
     ///
-    /// The one-term expression represents time bound as a weight on the R1CS constant `1` (see `const`).
+    /// The one-term expression represents time bound as a weight on the R1CS constant `1` (see `scalar`).
     Mintime,
 
     /// **maxtime** → _expr_
     ///
     /// Pushes an _expression_ `expr` corresponding to the _maximum time bound_ of the transaction.
     ///
-    /// The one-term expression represents time bound as a weight on the R1CS constant `1` (see `const`).
+    /// The one-term expression represents time bound as a weight on the R1CS constant `1` (see `scalar`).
     Maxtime,
 
     /// _var_ **expr** → _ex_
@@ -315,7 +315,10 @@ pub enum Instruction {
     /// 1. Pops `2·n` _points_ as pairs of _flavor_ and _quantity_ for each output value, flavor is popped first in each pair.
     /// 2. Pops `m` _wide values_ as input values.
     /// 3. Creates constraints and 64-bit range proofs for quantities per _Cloak protocol_.
-    /// 4. Pushes `n` _values_ to the stack, placing them in the same order as their corresponding commitments.
+    /// 4. Pushes `n` _values_ to the stack, placing them in the **reverse** order as their corresponding commitments:
+    ///    ```ascii
+    ///    A B C → cloak → C B A
+    ///    ```
     ///
     /// Immediate data `m` and `n` are encoded as two _LE32_s.
     Cloak(usize, usize),
@@ -508,8 +511,8 @@ pub enum Opcode {
     Dup = 0x03,
     /// A code for [Instruction::Roll].
     Roll = 0x04,
-    /// A code for [Instruction::Const].
-    Const = 0x05,
+    /// A code for [Instruction::Scalar].
+    Scalar = 0x05,
     /// A code for [Instruction::Var]
     Var = 0x06,
     /// A code for [Instruction::Alloc]
@@ -612,7 +615,7 @@ impl Encodable for Instruction {
                 write(Opcode::Roll)?;
                 w.write_u32(b"k", *idx as u32)?;
             }
-            Instruction::Const => write(Opcode::Const)?,
+            Instruction::Scalar => write(Opcode::Scalar)?,
             Instruction::Var => write(Opcode::Var)?,
             Instruction::Alloc(_) => write(Opcode::Alloc)?,
             Instruction::Mintime => write(Opcode::Mintime)?,
@@ -711,7 +714,7 @@ impl Instruction {
                 let idx = program.read_size()?;
                 Ok(Instruction::Roll(idx))
             }
-            Opcode::Const => Ok(Instruction::Const),
+            Opcode::Scalar => Ok(Instruction::Scalar),
             Opcode::Var => Ok(Instruction::Var),
             Opcode::Alloc => Ok(Instruction::Alloc(None)),
             Opcode::Mintime => Ok(Instruction::Mintime),

--- a/zkvm/src/ops.rs
+++ b/zkvm/src/ops.rs
@@ -58,21 +58,21 @@ pub enum Instruction {
     /// Fails if `a` is not a valid _scalar_.
     Scalar,
 
-    /// _P_ **var** → _v_
+    /// _P_ **commit** → _v_
     ///
     /// 1. Pops a _point_ `P` from the stack.
     /// 2. Creates a _variable_ `v` from a _Pedersen commitment_ `P`.
     /// 3. Pushes `v` to the stack.
     ///
     /// Fails if `P` is not a valid _point_.
-    Var,
+    Commit,
 
     /// **alloc** → _expr_
     ///
     /// 1. Allocates a low-level variable in the _constraint system_ and wraps it in the _expression_ with weight 1.
     /// 2. Pushes the resulting expression to the stack.
     ///
-    /// This is different from `var`: the variable created by `alloc` is _not_ represented by an individual Pedersen commitment and therefore can be chosen freely when the transaction is constructed.
+    /// This is different from `commit`: the variable created by `alloc` is _not_ represented by an individual Pedersen commitment and therefore can be chosen freely when the transaction is constructed.
     Alloc(Option<ScalarWitness>),
 
     /// **mintime** → _expr_
@@ -513,8 +513,8 @@ pub enum Opcode {
     Roll = 0x04,
     /// A code for [Instruction::Scalar].
     Scalar = 0x05,
-    /// A code for [Instruction::Var]
-    Var = 0x06,
+    /// A code for [Instruction::Commit]
+    Commit = 0x06,
     /// A code for [Instruction::Alloc]
     Alloc = 0x07,
     /// A code for [Instruction::Mintime]
@@ -616,7 +616,7 @@ impl Encodable for Instruction {
                 w.write_u32(b"k", *idx as u32)?;
             }
             Instruction::Scalar => write(Opcode::Scalar)?,
-            Instruction::Var => write(Opcode::Var)?,
+            Instruction::Commit => write(Opcode::Commit)?,
             Instruction::Alloc(_) => write(Opcode::Alloc)?,
             Instruction::Mintime => write(Opcode::Mintime)?,
             Instruction::Maxtime => write(Opcode::Maxtime)?,
@@ -715,7 +715,7 @@ impl Instruction {
                 Ok(Instruction::Roll(idx))
             }
             Opcode::Scalar => Ok(Instruction::Scalar),
-            Opcode::Var => Ok(Instruction::Var),
+            Opcode::Commit => Ok(Instruction::Commit),
             Opcode::Alloc => Ok(Instruction::Alloc(None)),
             Opcode::Mintime => Ok(Instruction::Mintime),
             Opcode::Maxtime => Ok(Instruction::Maxtime),

--- a/zkvm/src/program.rs
+++ b/zkvm/src/program.rs
@@ -158,7 +158,7 @@ impl Program {
     def_op!(dup, Dup, usize, "dup:k");
     def_op!(roll, Roll, usize, "roll:k");
     def_op!(scalar, Scalar, "scalar");
-    def_op!(var, Var, "var");
+    def_op!(commit, Commit, "commit");
     def_op!(alloc, Alloc, Option::<ScalarWitness>, "alloc");
     def_op!(mintime, Mintime, "mintime");
     def_op!(maxtime, Maxtime, "maxtime");

--- a/zkvm/src/program.rs
+++ b/zkvm/src/program.rs
@@ -157,7 +157,7 @@ impl Program {
     def_op!(drop, Drop, "drop");
     def_op!(dup, Dup, usize, "dup:k");
     def_op!(roll, Roll, usize, "roll:k");
-    def_op!(r#const, Const, "const");
+    def_op!(scalar, Scalar, "scalar");
     def_op!(var, Var, "var");
     def_op!(alloc, Alloc, Option::<ScalarWitness>, "alloc");
     def_op!(mintime, Mintime, "mintime");

--- a/zkvm/src/vm.rs
+++ b/zkvm/src/vm.rs
@@ -153,7 +153,7 @@ where
                 Instruction::Dup(i) => self.dup(i)?,
                 Instruction::Roll(i) => self.roll(i)?,
                 Instruction::Scalar => self.scalar()?,
-                Instruction::Var => self.var()?,
+                Instruction::Commit => self.commit()?,
                 Instruction::Alloc(sw) => self.alloc(sw)?,
                 Instruction::Mintime => self.mintime()?,
                 Instruction::Maxtime => self.maxtime()?,
@@ -317,7 +317,7 @@ where
         Ok(())
     }
 
-    fn var(&mut self) -> Result<(), VMError> {
+    fn commit(&mut self) -> Result<(), VMError> {
         let commitment = self.pop_item()?.to_string()?.to_commitment()?;
         let v = Variable { commitment };
         self.push_item(v);

--- a/zkvm/src/vm.rs
+++ b/zkvm/src/vm.rs
@@ -152,7 +152,7 @@ where
                 Instruction::Drop => self.drop()?,
                 Instruction::Dup(i) => self.dup(i)?,
                 Instruction::Roll(i) => self.roll(i)?,
-                Instruction::Const => self.r#const()?,
+                Instruction::Scalar => self.scalar()?,
                 Instruction::Var => self.var()?,
                 Instruction::Alloc(sw) => self.alloc(sw)?,
                 Instruction::Mintime => self.mintime()?,
@@ -311,7 +311,7 @@ where
         Ok(())
     }
 
-    fn r#const(&mut self) -> Result<(), VMError> {
+    fn scalar(&mut self) -> Result<(), VMError> {
         let scalar_witness = self.pop_item()?.to_string()?.to_scalar()?;
         self.push_item(Expression::constant(scalar_witness));
         Ok(())

--- a/zkvm/tests/zkvm.rs
+++ b/zkvm/tests/zkvm.rs
@@ -462,9 +462,9 @@ fn spend_with_secret_scalar(qty: u64, flavor: Scalar, pred: Predicate, secret: S
     Program::build(|p| {
         p.cloak_helper(1, vec![(qty, flavor)])
             .output_helper(pred)
-            .r#const()
+            .scalar()
             .push(secret)
-            .r#const()
+            .scalar()
             .eq()
             .verify();
     })

--- a/zkvm/tests/zkvm.rs
+++ b/zkvm/tests/zkvm.rs
@@ -25,9 +25,9 @@ trait ProgramHelper {
 impl ProgramHelper for Program {
     fn issue_helper(&mut self, qty: u64, flv: Scalar, issuance_pred: Predicate) -> &mut Self {
         self.push(Commitment::blinded_with_factor(qty, Scalar::from(1u64))) // stack: qty
-            .var() // stack: qty-var
+            .commit() // stack: qty-var
             .push(Commitment::unblinded(flv)) // stack: qty-var, flv
-            .var() // stack: qty-var, flv-var
+            .commit() // stack: qty-var, flv-var
             .push(String::default()) // stack: qty-var, flv-var, data
             .push(issuance_pred) // stack: qty-var, flv-var, data, pred
             .issue() // stack: issue-contract
@@ -580,9 +580,9 @@ fn borrow_output() {
     let borrow_prog = Program::build(|p| {
         p.input_helper(10, flv, preds[1].clone()) // stack: Value(10,1)
             .push(Commitment::blinded(5u64)) // stack: Value(10,1), qty(5)
-            .var() // stack: Value(10,1), qty-var(5)
+            .commit() // stack: Value(10,1), qty-var(5)
             .push(Commitment::blinded(flv)) // stack: Value(10,1), qty-var(5),   flv(1)
-            .var() // stack: Value(10,1), qty-var(5),   flv-var(1)
+            .commit() // stack: Value(10,1), qty-var(5),   flv-var(1)
             .borrow() // stack: Value(10,1), Value(-5, 1), Value(5,1)
             .output_helper(preds[0].clone()) // stack: Value(10,1), Value(-5, 1); outputs (5,1)
             .cloak_helper(2, vec![(5u64, flv)]) // stack:  Value(5,1)


### PR DESCRIPTION
Closes #482.

* `const` -> `scalar` for instantiating clear-text scalar values
* `var` -> `commit` for high-level variables tied to Pedersen commitments ("external facts")
* unchanged: `alloc` for low-level variables not tied to any external commitments.
 