### PR TITLE
zkvm: predicate carries optional witness

### DIFF
--- a/accounts/src/address.rs
+++ b/accounts/src/address.rs
@@ -22,7 +22,7 @@ use curve25519_dalek::traits::{IsIdentity, VartimeMultiscalarMul};
 use merlin::Transcript;
 use zkvm::bulletproofs::PedersenGens;
 use zkvm::encoding::Encodable;
-use zkvm::{ClearValue, Commitment, Predicate, TranscriptProtocol, Value};
+use zkvm::{ClearValue, Commitment, Predicate, TranscriptProtocol, Value, VerificationKey};
 
 use super::Receiver;
 
@@ -94,7 +94,7 @@ impl Address {
 
     /// Returns the control key wrapped in opaque ZkVM predicate type.
     pub fn predicate(&self) -> Predicate {
-        Predicate::Opaque(self.control_key)
+        Predicate::new(VerificationKey::from_compressed(self.control_key))
     }
 
     /// Encodes address as bech32 string with the label as its prefix.

--- a/accounts/src/receiver.rs
+++ b/accounts/src/receiver.rs
@@ -60,12 +60,6 @@ impl ReceiverWitness {
 
     /// Returns the predicate built out of the witness
     pub fn predicate(&self) -> Predicate {
-        // If we have a witness object, we know that our predicate is
-        // (1) correct Ristretto point,
-        // (2) a simple public key.
-        // Therefore, we can simply unwrap.
-        // TBD: We can derive the pubkey on the fly
-        // with static guarantees of correctness.
         Predicate::new(VerificationKey::from_compressed(
             self.receiver.opaque_predicate,
         ))

--- a/accounts/src/receiver.rs
+++ b/accounts/src/receiver.rs
@@ -58,7 +58,7 @@ impl ReceiverWitness {
         }
     }
 
-    /// Returns `Predicate::Key`
+    /// Returns the predicate built out of the witness
     pub fn predicate(&self) -> Predicate {
         // If we have a witness object, we know that our predicate is
         // (1) correct Ristretto point,
@@ -66,7 +66,9 @@ impl ReceiverWitness {
         // Therefore, we can simply unwrap.
         // TBD: We can derive the pubkey on the fly
         // with static guarantees of correctness.
-        Predicate::Key(VerificationKey::from_compressed(self.receiver.opaque_predicate).unwrap())
+        Predicate::new(VerificationKey::from_compressed(
+            self.receiver.opaque_predicate,
+        ))
     }
 
     /// Creates a new contract for the given receiver and an anchor.
@@ -95,7 +97,7 @@ impl Receiver {
 
     /// Returns the predicate object.
     pub fn predicate(&self) -> Predicate {
-        Predicate::Opaque(self.opaque_predicate)
+        Predicate::new(VerificationKey::from_compressed(self.opaque_predicate))
     }
 
     /// Constructs a value object from the qty, flavor and blinding factors.

--- a/accounts/src/tests.rs
+++ b/accounts/src/tests.rs
@@ -212,7 +212,10 @@ fn basic_accounts_test() {
 
         let sig = Signature::sign_multi(
             &signing_keys[..],
-            utx.signing_instructions.clone(),
+            utx.signing_instructions
+                .iter()
+                .map(|(p, m)| (p.verification_key(), m))
+                .collect(),
             &mut signtx_transcript,
         )
         .unwrap();

--- a/blockchain/src/tests.rs
+++ b/blockchain/src/tests.rs
@@ -62,7 +62,10 @@ fn dummy_tx(utxo: UTXO, bp_gens: &BulletproofGens) -> (BlockTx, UTXO) {
 
         let sig = Signature::sign_multi(
             &[privkey],
-            utx.signing_instructions.clone(),
+            utx.signing_instructions
+                .iter()
+                .map(|(p, m)| (p.verification_key(), m))
+                .collect(),
             &mut signtx_transcript,
         )
         .unwrap();

--- a/blockchain/src/tests.rs
+++ b/blockchain/src/tests.rs
@@ -10,7 +10,7 @@ use zkvm::{
 };
 
 fn make_predicate(privkey: impl Into<Scalar>) -> Predicate {
-    Predicate::Key(VerificationKey::from_secret(&privkey.into()))
+    Predicate::new(VerificationKey::from_secret(&privkey.into()))
 }
 
 fn nonce_flavor() -> Scalar {

--- a/demo/src/account.rs
+++ b/demo/src/account.rs
@@ -354,7 +354,7 @@ impl Wallet {
                 p.signtx();
 
                 let issuance_predicate =
-                    zkvm::Predicate::Key(zkvm::VerificationKey::from_secret(&issuance_key));
+                    zkvm::Predicate::new(zkvm::VerificationKey::from_secret(&issuance_key));
 
                 p.push(zkvm::Commitment::blinded(payment_receiver.value.qty)) // stack: qty
                     .commit() // stack: qty-var

--- a/demo/src/account.rs
+++ b/demo/src/account.rs
@@ -433,7 +433,10 @@ impl Wallet {
 
             let sig = musig::Signature::sign_multi(
                 &signing_keys[..],
-                utx.signing_instructions.clone(),
+                utx.signing_instructions
+                    .iter()
+                    .map(|(p, m)| (p.verification_key(), m))
+                    .collect(),
                 &mut signtx_transcript,
             )
             .unwrap();
@@ -594,7 +597,10 @@ impl Wallet {
 
             let sig = musig::Signature::sign_multi(
                 &signing_keys[..],
-                utx.signing_instructions.clone(),
+                utx.signing_instructions
+                    .iter()
+                    .map(|(p, m)| (p.verification_key(), m))
+                    .collect(),
                 &mut signtx_transcript,
             )
             .unwrap();

--- a/demo/src/asset.rs
+++ b/demo/src/asset.rs
@@ -20,7 +20,7 @@ struct AssetDefinition {
 impl AssetDefinition {
     pub fn issuance_predicate(&self) -> zkvm::Predicate {
         let vkey = zkvm::VerificationKey::from_secret(&self.issuance_key);
-        zkvm::Predicate::Key(vkey)
+        zkvm::Predicate::new(vkey)
     }
 
     pub fn metadata(&self) -> zkvm::String {

--- a/node/src/wallet.rs
+++ b/node/src/wallet.rs
@@ -179,7 +179,6 @@ impl Wallet {
 
     /// Lists all registered assets.
     pub fn list_assets<'a>(&'a self) -> impl Iterator<Item = (&'a str, Token)> {
-        //let xpub = self.xpub;
         self.assets
             .iter()
             .map(move |(_flv, alias)| (alias.as_str(), self.xpub.derive_token(&alias)))

--- a/node/src/wallet.rs
+++ b/node/src/wallet.rs
@@ -719,9 +719,9 @@ impl Utxo {
         // (1) a correct Ristretto point,
         // (2) a simple public key.
         // Therefore, we can simply unwrap.
-        let predicate = Predicate::Key(
-            VerificationKey::from_compressed(self.receiver.opaque_predicate).unwrap(),
-        );
+        let predicate = Predicate::new(VerificationKey::from_compressed(
+            self.receiver.opaque_predicate,
+        ));
         // TBD: Instead of unwrap-decompressing the key, derive it directly from xpub with a given sequence number.
 
         Contract {

--- a/node/src/wallet.rs
+++ b/node/src/wallet.rs
@@ -687,7 +687,11 @@ impl BuiltTx {
 
         let sig = musig::Signature::sign_multi(
             &signing_keys[..],
-            self.unsigned_tx.signing_instructions.clone(),
+            self.unsigned_tx
+                .signing_instructions
+                .iter()
+                .map(|(p, m)| (p.verification_key(), m))
+                .collect(),
             &mut signtx_transcript,
         )
         .unwrap();

--- a/paychan/src/lib.rs
+++ b/paychan/src/lib.rs
@@ -1,0 +1,219 @@
+use curve25519_dalek::scalar::Scalar;
+use merlin::Transcript;
+use musig::{Multikey, Signature};
+use zkvm::{ClearValue, Commitment, Predicate, PredicateTree, Program, Value, VerificationKey};
+
+fn blinded_value(v: ClearValue) -> Value {
+    Value {
+        qty: Commitment::blinded(v.qty),
+        flv: Commitment::blinded(v.flv),
+    }
+}
+
+// Creates program: `<qty> commit <flv> commit borrow => -V +V`
+fn borrow_value(p: &mut Program, v: Value) {
+    p.push(v.qty).commit().push(v.flv).commit().borrow();
+}
+
+fn output_value(p: &mut Program, value: Value, pred: Predicate) {
+    // qty commit flv commit borrow => -v +v
+    borrow_value(p, v);
+    p.push(zkvm::String::Predicate(Box::new(pred)));
+    p.output(1);
+}
+
+// locks a list of values under a predicate, and leaves negative values on stack.
+fn output_multiple_values(
+    p: &mut Program,
+    values: impl ExactSizeIterator<Item = Value>,
+    pred: Predicate,
+) {
+    let n = values.len();
+    if n == 0 {
+        return;
+    } else if n == 1 {
+        return output_value(p, values.next().expect("Should have 1 value"), pred);
+    }
+
+    for v in values {
+        // qty commit flv commit borrow => -v +v
+        borrow_value(p, v)
+    }
+    // n = 1: no rolls
+    // n = 2: -a +a -b +b: roll 2, roll 1
+    // n = 3: -a +a -b +b -c +c: roll 4, roll 3, roll 2
+    // n = 4: -a +a -b +b -c +c -d +d: roll 6, roll 5, roll 4, roll 3
+    // =>  roll 2(n-1)-i  n times
+    let mut i = 0;
+    while i < n {
+        p.roll(2 * (n - 1) - i);
+        i += 1;
+    }
+    p.push(zkvm::String::Predicate(Box::new(pred)));
+    p.output(n);
+}
+
+#[test]
+fn test() {
+    let alice_prv = Scalar::from(1u64);
+    let bob_prv = Scalar::from(2u64);
+
+    let alice = VerificationKey::from_secret(&alice_prv);
+    let bob = VerificationKey::from_secret(&bob_prv);
+
+    let alice_bob_joined = Multikey::new(vec![alice.clone(), bob.clone()])
+        .expect("won't fail")
+        .aggregated_key();
+
+    let flv = Scalar::zero();
+    let alice_qty = 100u64;
+    let bob_qty = 100u64;
+    let shared_value = blinded_value(ClearValue {
+        qty: alice_qty + bob_qty,
+        flv,
+    });
+
+    let values = vec![shared_value];
+    let alice_original_balances = vec![blinded_value(ClearValue {
+        qty: alice_qty,
+        flv,
+    })];
+    let bob_original_balances = vec![blinded_value(ClearValue { qty: bob_qty, flv })];
+    let assets_count = values.len();
+    let taproot_exit_blinding = [0u8; 32]; // TBD: real random
+    let taproot_init_blinding = [0u8; 32]; // TBD: real random
+
+    // TBD: generate unique tag for this contract from both keys and initial balances.
+    // Each party is supposed to have unique keys so the tag is not reused in other channels.
+    // Ideally, we'd tie the tag to the coins we are going to spend (can't duplicate that),
+    // but that adds extra coupling between preparation of the contract and actual tx signing.
+
+    let channel_tag = [0u8; 32].to_vec();
+
+    // Step 1: Alice and Bob prepare a contract that consists of:
+    // 1.1. Exit contract
+    // 1.2. Initial contract
+    // 1.3. Pre-signed initial distribution
+    //
+    // Initial contract embeds the exit predicate, so it is computed second.
+    // The goal of the initial contract is to provide a bridge into the
+    // "exiting" state state that can be overriden with a distribution program.
+
+    // 1.1. Exit contract
+    // Expected layout:
+    // [value, sequence, timeout, program, tag]
+    //
+    // P_exit = AB + program {
+    //     verify(tx.mintime > self.timeout)
+    //     eval(self.redistribution_program)
+    // }
+    let exit_predicate = Predicate::tree(
+        PredicateTree::new(
+            Some(alice_bob_joined.clone()),
+            vec![zkvm::Program::build(|p| {
+                // stack: assets, seq, timeout, prog, tag
+                // timeout is checked as a range proof
+                // tx.mintime > self.timeout =>
+                // tx.mintime - self.timeout > 0
+                p.dup(2) // copy the timeout from the stack
+                    .commit()
+                    .neg()
+                    .mintime()
+                    .add()
+                    .range()
+                    // then, evaluate the distribution program
+                    .roll(1); // we won't need to keep the program, so move it to the top
+
+                // TBD: need a plain "call" instruction to evaluate in-place w/o rewrapping.
+                // rewrapping the whole thing in another taproot
+            })],
+            taproot_exit_blinding,
+        )
+        .expect("won't fail"),
+    );
+
+    // 1.2. Initial contract
+
+    //    P_init = AB + program {
+    //         // transient contract:
+    //         contract(payload {
+    //            assets,
+    //            seq=0,
+    //            timeout=MAX_INT,
+    //            "" (empty prog),
+    //            tag
+    //         ) -> P_exit
+    //    }
+    let initial_predicate = Predicate::tree(
+        PredicateTree::new(
+            Some(alice_bob_joined.clone()),
+            vec![zkvm::Program::build(|p| {
+                // This is a simple adaptor contract that prepares a good format for applying
+                // the pre-signed exit program.
+                p.push(zkvm::String::U64(0))
+                    .push(zkvm::String::Commitment(Box::new(Commitment::unblinded(
+                        u64::max_value(),
+                    ))))
+                    .push(zkvm::String::Opaque(Program::new().to_bytes()))
+                    .push(zkvm::String::Opaque(channel_tag))
+                    .push(zkvm::String::Predicate(Box::new(exit_predicate.clone())))
+                    .contract(assets_count + 1 + 1 + 1 + 1);
+            })],
+            taproot_init_blinding,
+        )
+        .expect("won't fail"),
+    );
+
+    // 1.3. Pre-signed initial distribution
+    let initial_distribution = Program::build(|p| {
+        output_multiple_values(
+            p,
+            alice_original_balances.into_iter(),
+            Predicate::new(alice.clone()),
+        );
+        output_multiple_values(
+            p,
+            bob_original_balances.into_iter(),
+            Predicate::new(bob.clone()),
+        );
+    });
+
+    // override program:
+    // program($seq, $tx, $new_distribution) = {
+    //     verify($seq > self.seq)
+    //     self.redistribution_program = $new_distribution
+    //     self.timeout = $tx.maxtime+T
+    //     lock(self, P_exit)
+    // }
+    let initial_exit = Program::build(|p| {
+        // stack: assets, seq, timeout, prog, tag
+        p.dup(3); // copy the seq from the stack
+                  // TBD: check the sequence, update timeout and redistribution program
+                  // TBD: tx.maxtime must be constrained close to mintime so we don't allow locking up resolution too far in the future.
+    });
+
+    // Produce a signature for the initial distribution
+    // message formatted for signtag instruction.
+    let mut t = Transcript::new(b"ZkVM.signtag");
+    t.append_message(b"tag", &channel_tag[..]);
+    t.append_message(b"prog", &initial_exit.to_bytes());
+    let initial_exit_signature = Signature::sign(
+        &mut t,
+        Multikey::aggregated_signing_key(&vec![alice_prv, bob_prv]),
+    );
+
+    // Step 2: Alice and Bob co-sign a tx that locks up their funds in the initial contract.
+    // In this example we just cook up a serialized contract that we'll be spending.
+
+    // Step 3: Alice and Bob co-sign distribution program and exchange funds indefinitely
+
+    // Case A: Alice and Bob co-sign exit from the channel
+
+    // Case B: Alice closes channel with the latest version.
+
+    // Case C: Alice detects that channel was closed by Bob and updates her wallet state.
+
+    // Case D: Alice detects that channel was closed by Bob with a stale update and sends out a newer version.
+
+    assert_eq!("a", "b");
+}

--- a/starsig/src/key.rs
+++ b/starsig/src/key.rs
@@ -26,8 +26,8 @@ impl VerificationKey {
     }
 
     /// Creates new key from a compressed form, remembers the compressed point.
-    pub fn from_compressed(p: CompressedRistretto) -> Option<Self> {
-        Some(VerificationKey { point: p })
+    pub fn from_compressed(p: CompressedRistretto) -> Self {
+        VerificationKey { point: p }
     }
 
     /// Converts the Verification key to a compressed point

--- a/starsig/src/tests.rs
+++ b/starsig/src/tests.rs
@@ -24,6 +24,11 @@ fn sign_and_verify_single() {
 }
 
 #[test]
+fn empty_batch() {
+    let batch = BatchVerifier::new(rand::thread_rng());
+    assert_eq!(batch.verify(), Ok(()));
+}
+#[test]
 fn sign_and_verify_batch() {
     let prv1 = Scalar::from(1u64);
     let prv2 = Scalar::from(2u64);

--- a/token/src/derivation.rs
+++ b/token/src/derivation.rs
@@ -42,7 +42,7 @@ impl XpubDerivation for Xpub {
     fn derive_token(&self, alias: &str) -> Token {
         let key = self.issuing_key(alias);
         Token::new(
-            zkvm::Predicate::Opaque(*key.as_point()),
+            zkvm::Predicate::new(VerificationKey::from_compressed(*key.as_point())),
             alias.as_bytes().to_vec(),
         )
     }

--- a/token/src/token.rs
+++ b/token/src/token.rs
@@ -73,7 +73,7 @@ mod tests {
 
     fn add_dummy_input(p: &mut Program, dummy_key: &Scalar) {
         let contract = Contract {
-            predicate: Predicate::Key(VerificationKey::from_secret(dummy_key)),
+            predicate: Predicate::new(VerificationKey::from_secret(dummy_key)),
             payload: vec![],
             anchor: Anchor::from_raw_bytes([0u8; 32]),
         };
@@ -87,10 +87,10 @@ mod tests {
             let dest_key = Scalar::from(2u64);
             let dummy_key = Scalar::from(3u64);
             let usd = Token::new(
-                Predicate::Key(VerificationKey::from_secret(&issue_key)),
+                Predicate::new(VerificationKey::from_secret(&issue_key)),
                 b"USD".to_vec(),
             );
-            let dest = Predicate::Key(VerificationKey::from_secret(&dest_key));
+            let dest = Predicate::new(VerificationKey::from_secret(&dest_key));
 
             let program = Program::build(|p| {
                 add_dummy_input(p, &dummy_key);
@@ -112,10 +112,10 @@ mod tests {
             let dest_key = Scalar::from(2u64);
             let dummy_key = Scalar::from(3u64);
             let usd = Token::new(
-                Predicate::Key(VerificationKey::from_secret(&issue_key)),
+                Predicate::new(VerificationKey::from_secret(&issue_key)),
                 b"USD".to_vec(),
             );
-            let dest = Predicate::Key(VerificationKey::from_secret(&dest_key));
+            let dest = Predicate::new(VerificationKey::from_secret(&dest_key));
             let issue_program = Program::build(|p| {
                 add_dummy_input(p, &dummy_key);
                 usd.issue_to(p, 10u64, dest.clone());

--- a/zkvm/docs/zkvm-api.md
+++ b/zkvm/docs/zkvm-api.md
@@ -32,12 +32,7 @@ We call a type **witness** if it contains secret data and structure necessary fo
 
 ### Predicates
 
-[Predicate](zkvm-spec.md#predicate) is an enum:
-
-* `Predicate::Opaque` is an _opaque type_ to represent all predicates for the verifier’s VM.
-* `Predicate::Key` is a _witness type_ representing a signing key for [`signid`](zkvm-spec.md#signid), [`signtag`](zkvm-spec.md#signtag) and [`signtx`](zkvm-spec.md#signtx) instructions.
-* `Predicate::Tree` is a _witness type_ representing the [Taproot](zkvm-spec.md#taproot) Merkle tree for the [`call`](zkvm-spec.md#call) instruction.
-* `Predicate::Program` is a _witness type_ representing a program commitment for the [`call`](zkvm-spec.md#call) instruction.
+[Predicate](zkvm-spec.md#predicate) is a structure that encapsulates an opaque `VerificationKey` and an optional dynamically typed `PredicateWitness`. Witness may contain a private key directly, or metadata that helps creating a signature such as Multikey layout, derivation sequence number etc.
 
 ### Variables
 

--- a/zkvm/src/contract.rs
+++ b/zkvm/src/contract.rs
@@ -10,6 +10,7 @@ use crate::transcript::TranscriptProtocol;
 use crate::types::{String, Value};
 use crate::VMError;
 use merlin::Transcript;
+use musig::VerificationKey;
 
 /// Prefix for the string type in the Output Structure
 pub const STRING_TYPE: u8 = 0x00;
@@ -100,7 +101,7 @@ impl Decodable for Contract {
         //     Value  =  0x02  ||  <32 bytes> ||  <32 bytes>
 
         let anchor = Anchor(reader.read_u8x32()?);
-        let predicate = Predicate::Opaque(reader.read_point()?);
+        let predicate = Predicate::new(VerificationKey::from_compressed(reader.read_point()?));
         let k = reader.read_size()?;
         let payload: Vec<PortableItem> = reader.read_vec(k, |r| PortableItem::decode(r))?;
         Ok(Contract {

--- a/zkvm/src/debug.rs
+++ b/zkvm/src/debug.rs
@@ -146,11 +146,7 @@ impl Instruction {
 
 impl fmt::Debug for Predicate {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Predicate::Opaque(r) => write!(f, "0x{}", hex::encode(&r.as_bytes())),
-            Predicate::Key(vk) => write!(f, "0x{}", hex::encode(&vk.as_bytes())),
-            Predicate::Tree(pt) => write!(f, "{:?}", pt),
-        }
+        write!(f, "0x{}", hex::encode(&self.verification_key().as_bytes()))
     }
 }
 

--- a/zkvm/src/lib.rs
+++ b/zkvm/src/lib.rs
@@ -36,7 +36,7 @@ pub use self::contract::{Anchor, Contract, ContractID, PortableItem};
 pub use self::errors::VMError;
 pub use self::fees::{fee_flavor, CheckedFee, FeeRate, MAX_FEE};
 pub use self::ops::{Instruction, Opcode};
-pub use self::predicate::{Predicate, PredicateTree};
+pub use self::predicate::{Predicate, PredicateTree, PredicateWitness};
 pub use self::program::{Program, ProgramItem};
 pub use self::prover::Prover;
 pub use self::scalar_witness::ScalarWitness;

--- a/zkvm/src/predicate.rs
+++ b/zkvm/src/predicate.rs
@@ -21,7 +21,8 @@ use crate::program::{Program, ProgramItem};
 use crate::transcript::TranscriptProtocol;
 
 /// Prover-visible witness data for the predicate.
-/// This could be key derivation parameters, multi-party layout or even a private key.
+/// This could be key derivation parameters or multi-party layout.
+/// In tests it's common to store a private key as a witness.
 pub trait PredicateWitness: Any + Send + Debug {
     /// Computes the verification key from the witness.
     fn verification_key(&self) -> VerificationKey;
@@ -29,8 +30,8 @@ pub trait PredicateWitness: Any + Send + Debug {
     /// Clones the witness as a boxed trait object.
     fn clone_witness(&self) -> Box<dyn PredicateWitness>;
 
-    /// Bridge to Any type that allows us perform downcasting.
-    /// Your type typically returns `self` here.
+    /// Bridge to `Any` trait that supports downcasting.
+    /// Your type should typically return `self` from this method.
     fn as_any(&self) -> &dyn Any;
 }
 

--- a/zkvm/src/predicate.rs
+++ b/zkvm/src/predicate.rs
@@ -19,7 +19,7 @@ use crate::merkle::{Hash, Hasher, MerkleItem, MerkleTree, Path};
 use crate::program::{Program, ProgramItem};
 use crate::transcript::TranscriptProtocol;
 
-pub trait PredicateWitness: Any {
+pub trait PredicateWitness: Any + Send {
     fn clone_witness(&self) -> Box<dyn PredicateWitness>;
 }
 /// Represents a ZkVM predicate with its optional witness data.

--- a/zkvm/src/program.rs
+++ b/zkvm/src/program.rs
@@ -65,27 +65,27 @@ macro_rules! def_op {
 }
 
 macro_rules! def_op_inner {
-    ($func_name:ident, $op:ident, $doc_expr:expr) => (
+    ($func_name:ident, $op:ident, $doc_expr:expr) => {
         #[doc = $doc_expr]
-        pub fn $func_name(&mut self) -> &mut Program{
+        pub fn $func_name(&mut self) -> &mut Program {
             self.0.push(Instruction::$op);
             self
         }
-    );
-    ($func_name:ident, $op:ident, $arg_type:ty, $doc_expr:expr) => (
+    };
+    ($func_name:ident, $op:ident, $arg_type:ty, $doc_expr:expr) => {
         #[doc = $doc_expr]
-        pub fn $func_name(&mut self, arg :$arg_type) -> &mut Program {
+        pub fn $func_name(&mut self, arg: $arg_type) -> &mut Program {
             self.0.push(Instruction::$op(arg));
             self
         }
-    );
-    ($func_name:ident, $op:ident, $arg_type1:ty, $arg_type2:ty, $doc_expr:expr) => (
+    };
+    ($func_name:ident, $op:ident, $arg_type1:ty, $arg_type2:ty, $doc_expr:expr) => {
         #[doc = $doc_expr]
         pub fn $func_name(&mut self, arg1: $arg_type1, arg2: $arg_type2) -> &mut Program {
             self.0.push(Instruction::$op(arg1, arg2));
             self
         }
-    );
+    };
 }
 
 impl Encodable for Program {

--- a/zkvm/src/prover.rs
+++ b/zkvm/src/prover.rs
@@ -48,7 +48,8 @@ impl<'t, 'g> Delegate<r1cs::Prover<'g, Transcript>> for Prover<'g> {
         pred: Predicate,
         contract_id: ContractID,
     ) -> Result<(), VMError> {
-        let k = pred.to_verification_key_witness()?;
+        // TBD: store predicate itself instead
+        let k = pred.verification_key();
         self.signtx_items.push((k, contract_id));
         Ok(())
     }

--- a/zkvm/src/prover.rs
+++ b/zkvm/src/prover.rs
@@ -3,7 +3,6 @@ use bulletproofs::r1cs::ConstraintSystem;
 use bulletproofs::{BulletproofGens, PedersenGens};
 use curve25519_dalek::ristretto::CompressedRistretto;
 use merlin::Transcript;
-use musig::VerificationKey;
 use std::collections::VecDeque;
 
 use crate::constraints::Commitment;

--- a/zkvm/src/prover.rs
+++ b/zkvm/src/prover.rs
@@ -22,7 +22,7 @@ use crate::vm::{Delegate, VM};
 /// creates a R1CS proof and returns a complete `Tx` object that can be published.
 pub struct Prover<'g> {
     // TBD: use Multikey as a witness thing
-    signtx_items: Vec<(VerificationKey, ContractID)>,
+    signtx_items: Vec<(Predicate, ContractID)>,
     cs: r1cs::Prover<'g, Transcript>,
     batch: musig::BatchVerifier<rand::rngs::ThreadRng>,
 }
@@ -48,9 +48,7 @@ impl<'t, 'g> Delegate<r1cs::Prover<'g, Transcript>> for Prover<'g> {
         pred: Predicate,
         contract_id: ContractID,
     ) -> Result<(), VMError> {
-        // TBD: store predicate itself instead
-        let k = pred.verification_key();
-        self.signtx_items.push((k, contract_id));
+        self.signtx_items.push((pred, contract_id));
         Ok(())
     }
 

--- a/zkvm/src/tx.rs
+++ b/zkvm/src/tx.rs
@@ -2,7 +2,7 @@ use bulletproofs::r1cs::R1CSProof;
 use bulletproofs::BulletproofGens;
 use curve25519_dalek::ristretto::CompressedRistretto;
 use merlin::Transcript;
-use musig::{Signature, VerificationKey};
+use musig::Signature;
 use serde::{Deserialize, Serialize};
 
 use crate::contract::{Contract, ContractID};
@@ -10,6 +10,7 @@ use crate::encoding::*;
 use crate::errors::VMError;
 use crate::fees::FeeRate;
 use crate::merkle::{Hash, MerkleItem, MerkleTree};
+use crate::predicate::Predicate;
 use crate::transcript::TranscriptProtocol;
 use crate::verifier::Verifier;
 
@@ -76,7 +77,7 @@ pub struct UnsignedTx {
 
     /// List of (key,contractid) pairs for multi-message signature
     /// TBD: change to some key witness type
-    pub signing_instructions: Vec<(VerificationKey, ContractID)>,
+    pub signing_instructions: Vec<(Predicate, ContractID)>,
 }
 
 /// Instance of a transaction that contains all necessary data to validate it.

--- a/zkvm/src/types.rs
+++ b/zkvm/src/types.rs
@@ -2,6 +2,7 @@
 
 use curve25519_dalek::scalar::Scalar;
 use merlin::Transcript;
+use musig::VerificationKey;
 use serde::{Deserialize, Serialize};
 use spacesuit::{self, SignedInteger};
 
@@ -263,7 +264,7 @@ impl String {
         match self {
             String::Opaque(data) => {
                 let point = (&data[..]).read_all(|r| r.read_point())?;
-                Ok(Predicate::Opaque(point))
+                Ok(Predicate::new(VerificationKey::from_compressed(point)))
             }
             String::Predicate(p) => Ok(*p),
             _ => Err(VMError::TypeNotPredicate),

--- a/zkvm/src/verifier.rs
+++ b/zkvm/src/verifier.rs
@@ -51,7 +51,8 @@ impl Delegate<r1cs::Verifier<Transcript>> for Verifier {
         pred: Predicate,
         contract_id: ContractID,
     ) -> Result<(), VMError> {
-        let key = pred.to_verification_key()?;
+        // TBD: store predicate instead
+        let key = pred.verification_key();
         Ok(self.signtx_items.push((key, contract_id)))
     }
 

--- a/zkvm/src/vm.rs
+++ b/zkvm/src/vm.rs
@@ -624,7 +624,7 @@ where
         }
 
         // Verification key from predicate
-        let verification_key = contract.predicate.to_verification_key()?;
+        let verification_key = contract.predicate.verification_key();
 
         // Verify signature using Verification key, over the message `program`
         let mut t = Transcript::new(b"ZkVM.signid");
@@ -659,7 +659,7 @@ where
         self.push_item(tag.clone());
 
         // Verification key from predicate
-        let verification_key = contract.predicate.to_verification_key()?;
+        let verification_key = contract.predicate.verification_key();
 
         // Verify signature using Verification key, over the message `program`
         let mut t = Transcript::new(b"ZkVM.signtag");

--- a/zkvm/tests/zkvm.rs
+++ b/zkvm/tests/zkvm.rs
@@ -65,7 +65,7 @@ impl ProgramHelper for Program {
 /// Generates a secret Scalar / key Predicate pair
 fn generate_predicate() -> (Predicate, Scalar) {
     let scalar = Scalar::from(0u64);
-    let pred = Predicate::Key(VerificationKey::from_secret(&scalar));
+    let pred = Predicate::new(VerificationKey::from_secret(&scalar));
     (pred, scalar)
 }
 
@@ -81,7 +81,7 @@ fn generate_predicates(pred_num: usize) -> (Vec<Predicate>, Vec<Scalar>) {
 
     let predicates: Vec<Predicate> = scalars
         .iter()
-        .map(|s| Predicate::Key((s * gens.B).into()))
+        .map(|s| Predicate::new((s * gens.B).into()))
         .collect();
 
     (predicates, scalars)
@@ -91,7 +91,7 @@ fn generate_predicates(pred_num: usize) -> (Vec<Predicate>, Vec<Scalar>) {
 /// a flavor, along with the flavor Scalar.
 fn make_flavor() -> (Scalar, Predicate, Scalar) {
     let scalar = Scalar::from(100u64);
-    let predicate = Predicate::Key(VerificationKey::from_secret(&scalar));
+    let predicate = Predicate::new(VerificationKey::from_secret(&scalar));
     let flavor = Value::issue_flavor(&predicate, String::default());
     (scalar, predicate, flavor)
 }
@@ -476,13 +476,13 @@ fn taproot_happy_path() {
     let pk = VerificationKey::from_secret(&sk);
     let pred_tree = PredicateTree::new(Some(pk), vec![], [0u8; 32]).unwrap();
     let factor = pred_tree.adjustment_factor();
-    let prev_output = make_output(101u64, Scalar::from(1u64), Predicate::Tree(pred_tree));
+    let prev_output = make_output(101u64, Scalar::from(1u64), Predicate::tree(pred_tree));
 
     let prog = Program::build(|p| {
         p.push(prev_output)
             .input()
             .signtx()
-            .push(Predicate::Key(pk)) // send to the key
+            .push(Predicate::new(pk)) // send to the key
             .output(1);
     });
 
@@ -504,7 +504,7 @@ fn taproot_program_path() {
     let tree = PredicateTree::new(Some(pk), vec![spend_prog], blinding_key).unwrap();
     let factor = tree.adjustment_factor();
     let (call_proof, call_prog) = tree.create_callproof(0).unwrap();
-    let prev_output = make_output(qty, flavor, Predicate::Tree(tree));
+    let prev_output = make_output(qty, flavor, Predicate::tree(tree));
 
     let prog = Program::build(|p| {
         p.push(secret_scalar)


### PR DESCRIPTION
This changes the `Predicate` type from enum to a struct that holds optional dynamically typed `PredicateWitness`.

Witness is used for all the metadata that helps resolving the predicate on the prover's side:

1. Structure of the Taproot tree.
2. Verbatim private key for tests.
3. Keytree derivation sequence numbers.
4. Multikey layout (e.g. for 2-of-2 payment channel signatures).

**Checklist:**

- [x] core API changes
- [x] update tests to use verbatim privkey
- [x] add nested witness field for signing key inside PredicateTree
- [ ] ~update tests using Keytree to keep sequence numbers inside witness~ (will do in a separate PR)
- [x] add PredicateWitness::verification_key so we can generate full pubkey from the witness